### PR TITLE
Travis CI: Add comment linking to homebrew-openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       addons:
         homebrew:
           taps:
-            - AdoptOpenJDK/openjdk. # for Java
+            - AdoptOpenJDK/openjdk  # for Java
           casks:
             - adoptopenjdk11
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,11 @@ jobs:
       osx_image: xcode11.6  # Supports homebrew bundle without update
       # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
       # https://docs.travis-ci.com/user/installing-dependencies/
+      # https://github.com/AdoptOpenJDK/homebrew-openjdk
       addons:
         homebrew:
           taps:
-            - AdoptOpenJDK/openjdk    # for java
+            - AdoptOpenJDK/openjdk. # for Java
           casks:
             - adoptopenjdk11
       before_install:


### PR DESCRIPTION
https://travis-ci.org/github/jython/jython/pull_requests should be migrated to https://travis-ci.com instead of .org