### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,20 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit -r . || true
+      - run: black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: mypy --ignore-missing-imports . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,7 +9,7 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       #- run: black --check . || true  # Disable because it takes too long.
-      - run: codespell --ignore-words-list="als,ist,nd,ois,parm,parms,sie,te,titel.upto" --quiet-level=2 --skip="./Lib" || true
+      - run: codespell --ignore-words-list="als,ist,nd,ois,parm,parms,sie,spawnve,te,titel,upto" --quiet-level=2 --skip="./lib-python,./Lib" || true
       - run: flake8 --count --select=E9,F63,F7,F82 --show-source --statistics ./Demo ./tests
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,8 +9,8 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
       #- run: black --check . || true  # Disable because it takes too long.
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: codespell --ignore-words-list="als,ist,nd,ois,parm,parms,sie,te,titel.upto" --quiet-level=2 --skip="./Lib" || true
+      - run: flake8 --count --select=E9,F63,F7,F82 --show-source --statistics ./Demo ./tests
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: mypy --ignore-missing-imports . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,9 +7,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
-      - run: bandit -r . || true
+      #- run: bandit -r . || true  # Not so helpful
       #- run: black --check . || true  # Disable because it takes too long.
-      - run: codespell --ignore-words-list="als,ist,nd,ois,parm,parms,sie,spawnve,te,titel,upto" --quiet-level=2 --skip="./lib-python,./Lib" || true
+      - run: |
+          IGNORE_WORDS_LIST="als,ba,fo,inout,iself,ist,nd,ois,parm,parms,sie,spawnve,te,titel,ue,upto"
+          codespell --ignore-words-list=$IGNORE_WORDS_LIST --quiet-level=2 --skip="./lib-python,./Lib" || true
       - run: flake8 --count --select=E9,F63,F7,F82 --show-source --statistics ./Demo ./tests
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       #- run: bandit -r . || true  # Not so helpful
       #- run: black --check . || true  # Disable because it takes too long.

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit -r . || true
-      - run: black --check . || true
+      #- run: black --check . || true  # Disable because it takes too long.
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: |
           IGNORE_WORDS_LIST="als,ba,fo,inout,iself,ist,nd,ois,parm,parms,sie,spawnve,te,titel,ue,upto"
           codespell --ignore-words-list=$IGNORE_WORDS_LIST --quiet-level=2 --skip="./lib-python,./Lib" || true
-      - run: flake8 --count --select=E9,F63,F7,F82 --show-source --statistics ./Demo ./tests
+      - run: flake8 --count --select=E9,F63,F7,F82 --show-source --statistics ./Demo
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: mypy --ignore-missing-imports . || true


### PR DESCRIPTION
Run [codespell](https://github.com/codespell-project/codespell) to find typos.
Run [flake8](https://flake8.pycqa.org) to find Python 3 SyntaxErrors in `./Demo` and `./tests`

Output: https://github.com/cclauss/jython-2/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.