### PR TITLE
Fix CRC32#update calls in zlib.py

### DIFF
--- a/Lib/zlib.py
+++ b/Lib/zlib.py
@@ -19,7 +19,6 @@ import jarray
 import struct
 import sys
 from cStringIO import StringIO
-from org.python.core.util import StringUtil
 
 from java.lang import Long, String, System
 from java.util.zip import Adler32, CRC32, Deflater, Inflater, DataFormatException
@@ -149,7 +148,7 @@ class compressobj(object):
         self.deflater.setInput(string, 0, len(string))
         deflated = _get_deflate_data(self.deflater)
         self._size += len(string)
-        self._crc32.update(StringUtil.toBytes(string), 0, len(string))
+        self._crc32.update(string, 0, len(string))
         if self._gzip:
             return self.GZIP_HEADER + deflated
         else:
@@ -227,7 +226,7 @@ class decompressobj(object):
 
         self.inflater.setInput(string)
         inflated = _get_inflate_data(self.inflater, max_length)
-        self._crc32.update(StringUtil.toBytes(inflated), 0, len(inflated))
+        self._crc32.update(inflated, 0, len(inflated))
 
         r = self.inflater.getRemaining()
         if r:

--- a/Lib/zlib.py
+++ b/Lib/zlib.py
@@ -19,6 +19,7 @@ import jarray
 import struct
 import sys
 from cStringIO import StringIO
+from org.python.core.util import StringUtil
 
 from java.lang import Long, String, System
 from java.util.zip import Adler32, CRC32, Deflater, Inflater, DataFormatException
@@ -148,7 +149,7 @@ class compressobj(object):
         self.deflater.setInput(string, 0, len(string))
         deflated = _get_deflate_data(self.deflater)
         self._size += len(string)
-        self._crc32.update(string)
+        self._crc32.update(StringUtil.toBytes(string), 0, len(string))
         if self._gzip:
             return self.GZIP_HEADER + deflated
         else:
@@ -226,7 +227,7 @@ class decompressobj(object):
 
         self.inflater.setInput(string)
         inflated = _get_inflate_data(self.inflater, max_length)
-        self._crc32.update(inflated)
+        self._crc32.update(StringUtil.toBytes(inflated), 0, len(inflated))
 
         r = self.inflater.getRemaining()
         if r:

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ For more details, three sources are available according to type:
 
 Jython 2.7.3a1
   Bugs fixed
+    - [ GH-102 ] Fix CRC32.update calls in zlib.py
     - [ GH-35 ] Travis CI on JDKs 8, 11, 13 and add Windows to OSes
     - [ GH-50 ] (First) migration from Mercurial corrupted project history
     - [ GH-27 ] -Q new always fails


### PR DESCRIPTION
the update method within CRC32.java does not contain a signature that only accepts a single String input, it only accepts either (byte[], int, int) or (ByteBuffer), to which the byte[] input was an easier choice here