### PR TITLE
Re-instate Travis-CI for regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,14 @@ jobs:
         homebrew:
           taps:
             - homebrew/cask-versions # for openjdk
-          casks:
-            - openjdk@8
           packages:
             - ant
+            - openjdk@8
       before_install:
+        # Probe the brew Cellar
+        - brew --prefix
+        - brew list ant
+        - brew list openjdk@8
         # Make available to the JDK switcher.
         # See: https://formulae.brew.sh/formula/openjdk@8
         - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
@@ -65,7 +68,7 @@ jobs:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK and ant
         - choco install openjdk11 ant
-        - cat /c/ProgramData/chocolatey/logs/chocolatey.log
+        - tail --lines=200 /c/ProgramData/chocolatey/logs/chocolatey.log
         - ls -l /c/ProgramData/chocolatey/lib/ant/tools
         - ls -l "/c/Program Files/OpenJDK"
         # Does this access the new path?

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ jobs:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK and ant
         - choco install openjdk11 ant
-        - ls -l /c/ProgramData/chocolatey/bin
         # Chocolatey has updated the PATH, but only in powershell [Environment]
         # Dig out the path from [Environment] and translate it to Unix
         - posh_path=$(powershell -NonInteractive -Command
@@ -72,8 +71,22 @@ jobs:
         - echo $posh_path
         #- export PATH="$posh_path"
         # Can we get JAVA_HOME this way too?
-        - powershell -NonInteractive -Command  'RefreshEnv; Get-Command java'
-        - java_exe=$(powershell -NonInteractive -Command 'RefreshEnv; write((Get-Command java).Path)')
+        - powershell -NonInteractive -Command
+            '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
+            write((Get-Command java).Path)'
+        - java_exe=$(PATH=$posh_path powershell -NonInteractive -Command
+            '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
+            write((Get-Command java).Path)')
+        - echo $java_exe
+        - java_exe=$(cygpath "$java_exe")
+        - echo $java_exe
+        - echo ${java_exe%/bin/*}
+        - export JAVA_HOME="${java_exe%/bin/*}"
+        - echo $JAVA_HOME
+        - export PATH="$JAVA_HOME/bin:$PATH"
+        # Another way to get JAVA_HOME
+        - PATH=$posh_path powershell -NonInteractive -Command  'Get-Command java'
+        - java_exe=$(PATH=$posh_path powershell -NonInteractive -Command 'write((Get-Command java).Path)')
         - echo $java_exe
         - java_exe=$(cygpath "$java_exe")
         - echo $java_exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,64 +16,60 @@ addons:
 jobs:
   include:
 
-    #- name: "openjdk8 on Linux"
-    #  dist: xenial
-    #  jdk: openjdk8
+    - name: "openjdk8 on Linux"
+      dist: xenial
+      jdk: openjdk8
 
 
-    #- name: "openjdk11 on Linux"
-    #  jdk: openjdk11
+    - name: "openjdk11 on Linux"
+      jdk: openjdk11
 
 
     #- name: "openjdk13 on Linux"
     #  jdk: openjdk13
 
 
-    #- name: "openjdk@8 on macOS xcode11.6"
-    #  os: osx
-    #  osx_image: xcode11.6  # Supports homebrew bundle without needing update
-    #  # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-    #  # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
-    #  addons:
-    #    homebrew:
-    #      taps:
-    #        - homebrew/cask-versions # for openjdk
-    #      packages:
-    #        - ant
-    #        - openjdk@8
-    #  before_install:
-    #    # Probe the brew Cellar
-    #    - brew --prefix
-    #    - brew list openjdk@8
-    #    # Make available to the JDK switcher.
-    #    # See: https://formulae.brew.sh/formula/openjdk@8
-    #    - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
-    #        /Library/Java/JavaVirtualMachines/openjdk-8.jdk
-    #    # Add the required JDK to the path
-    #    - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
-    #    - echo $JAVA_HOME
-    #    - export PATH="$JAVA_HOME/bin:$PATH"
+    - name: "openjdk@8 on macOS xcode11.6"
+      os: osx
+      osx_image: xcode11.6  # Supports homebrew bundle without needing update
+      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
+      # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
+      addons:
+        homebrew:
+          taps:
+            - homebrew/cask-versions # for openjdk
+          packages:
+            - ant
+            - openjdk@8
+      before_install:
+        # Probe the brew Cellar
+        - brew list openjdk@8
+        # Make available to the JDK switcher.
+        # See: https://formulae.brew.sh/formula/openjdk@8
+        - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
+            /Library/Java/JavaVirtualMachines/openjdk-8.jdk
+        # Add the required JDK to the path
+        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
+        - echo $JAVA_HOME
+        - export PATH="$JAVA_HOME/bin:$PATH"
 
 
     - name: "openjdk11 on Windows"
       os: windows
       language: bash  # Travis CI Windows does not yet support language: java
+
       before_install:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK and ant
         - choco install openjdk11 ant
-        # Chocolatey has updated the PATH, but only in powershell [Environment]
-        # Dig out the path from [Environment] and translate it to Unix
-        #- posh_path=$(powershell -NonInteractive -Command
-        #    'write(([Environment]::GetEnvironmentVariable("PATH","Machine") + ";" +
-        #            [Environment]::GetEnvironmentVariable("PATH","User")
-        #        ).replace("\","/").replace("C:","/c").replace(";",":"))')
-        #- echo $posh_path
-        #- export PATH="$posh_path"
-        # Can we get JAVA_HOME this way?
+
+        # Ant is installed on the (bash) PATH at /c/ProgramData/chocolatey/bin.
+        # Java is at /c/Program Files/OpenJDK/openjdk-<version-patch>/bin which is liable to change.
+        # Chocolatey has updated the PATH for Java, but only in powershell [Environment].
+        # Dig out the Java path from [Environment] and translate it to Unix.
         - java_exe=$(powershell -NonInteractive -Command
             '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
-            write((Get-Command java).Path)')
+                write((Get-Command java).Path)')
         - java_exe=$(cygpath "$java_exe")
         - echo $java_exe
         - export JAVA_HOME="${java_exe%/bin/*}"
@@ -91,9 +87,10 @@ jobs:
     - language: python
     - os: osx # remains flakey
 
-#
-# Common part to all hosts
-#
+
+####
+# Common part to all host OSes
+####
 
 # Install (i.e. build) Jython
 install:
@@ -103,14 +100,13 @@ install:
     - java -version
     - ant -version
     # Build Jython
-    #- ant developer-build
-    #- dist/bin/jython -V
+    - ant developer-build
 
 
 # Run the regression test (tweaked for Travis in build.xml)
 script:
-    # Disabled for now: only report environment
-    - ant dump-env
+    # Disabled for now: only report version (includes Java version)
+    - dist/bin/jython -V
     # Fairly full regression test
     #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ jobs:
       # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
       addons:
         homebrew:
-          update: false
           taps:
             - homebrew/cask-versions # for openjdk
           packages:
             - ant
             - openjdk@8
       before_install:
+        - export HOMEBREW_NO_AUTO_UPDATE=1
         # Probe the brew Cellar
         - brew list openjdk@8
         # Make available to the JDK switcher.

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,33 +64,18 @@ jobs:
         - choco install openjdk11 ant
         # Chocolatey has updated the PATH, but only in powershell [Environment]
         # Dig out the path from [Environment] and translate it to Unix
-        - posh_path=$(powershell -NonInteractive -Command
-            'write(([Environment]::GetEnvironmentVariable("PATH","Machine") + ";" +
-                    [Environment]::GetEnvironmentVariable("PATH","User")
-                ).replace("\","/").replace("C:","/c").replace(";",":"))')
-        - echo $posh_path
+        #- posh_path=$(powershell -NonInteractive -Command
+        #    'write(([Environment]::GetEnvironmentVariable("PATH","Machine") + ";" +
+        #            [Environment]::GetEnvironmentVariable("PATH","User")
+        #        ).replace("\","/").replace("C:","/c").replace(";",":"))')
+        #- echo $posh_path
         #- export PATH="$posh_path"
-        # Can we get JAVA_HOME this way too?
-        - powershell -NonInteractive -Command
-            '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
-            write((Get-Command java).Path)'
-        - java_exe=$(PATH=$posh_path powershell -NonInteractive -Command
+        # Can we get JAVA_HOME this way?
+        - java_exe=$(powershell -NonInteractive -Command
             '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
             write((Get-Command java).Path)')
-        - echo $java_exe
         - java_exe=$(cygpath "$java_exe")
         - echo $java_exe
-        - echo ${java_exe%/bin/*}
-        - export JAVA_HOME="${java_exe%/bin/*}"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
-        # Another way to get JAVA_HOME
-        - PATH=$posh_path powershell -NonInteractive -Command  'Get-Command java'
-        - java_exe=$(PATH=$posh_path powershell -NonInteractive -Command 'write((Get-Command java).Path)')
-        - echo $java_exe
-        - java_exe=$(cygpath "$java_exe")
-        - echo $java_exe
-        - echo ${java_exe%/bin/*}
         - export JAVA_HOME="${java_exe%/bin/*}"
         - echo $JAVA_HOME
         - export PATH="$JAVA_HOME/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,12 @@ jobs:
         # Install the required JDK and ant
         - choco install openjdk11 ant
         - ls -l /c/ProgramData/chocolatey/bin
-        # Chocolatey has updated the PATH, but only for a new powershell
-        # Dig out the path and translate it to Unix
+        # Chocolatey has updated the PATH, but only in powershell [Environment]
+        # Dig out the path from [Environment] and translate it to Unix
         - posh_path=$(powershell -NonInteractive -Command
-            'write($env:PATH.replace("\","/").replace("C:","/c").replace(";",":"))')
+            'write(([Environment]::GetEnvironmentVariable("PATH","Machine") + ";" +
+                    [Environment]::GetEnvironmentVariable("PATH","User"))
+                .replace("\","/").replace("C:","/c").replace(";",":"))')
         - echo $posh_path
         - export PATH="$posh_path"
         # Can we get JAVA_HOME this way too?

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       addons:
         homebrew:
           taps:
-            - homebrew/cask-core # for openjdk
+            - homebrew/cask-versions # for openjdk
           casks:
             - openjdk@8
           packages:
@@ -57,22 +57,20 @@ jobs:
       os: windows
       language: bash  # Travis CI Windows does not yet support language: java
       env:
-        # Control installation locations (see also before_install: section)
-        - JAVA_HOME="/c/Users/travis/build/jdk"
-        - ANT_HOME="/c/Users/travis/build/ant"
-        - PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+        # Installation locations? (see also before_install: section)
+        #- JAVA_HOME="/c/Users/travis/build/jdk"
+        #- ANT_HOME="/c/Users/travis/build/ant"
+        #- PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
       before_install:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
-        # Install the required JDK (at variables in env: section)
-        - cygpath -w "$JAVA_HOME"
-        - java_home=$(cygpath -w "$JAVA_HOME")
-        - echo "$java_home"
-        - choco install openjdk11 -params "installdir=$(cygpath -w $JAVA_HOME)" -y
-        # Install the required Ant (at variables in env: section)
-        - cygpath -w $ANT_HOME
-        - ant_home=$(cygpath -w "$ANT_HOME")
-        - echo "$ant_home"
-        - choco install ant -params "installdir=$ant_home" -y
+        # Install the required JDK and ant
+        - choco install openjdk11 ant
+        - cat /c/ProgramData/chocolatey/logs/chocolatey.log
+        - ls -l /c/ProgramData/chocolatey/lib/ant/tools
+        - ls -l "/c/Program Files/OpenJDK"
+        # Does this access the new path?
+        - bash -c 'echo $JAVA_HOME'
+        - bash -c 'echo $PATH'
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,30 +29,30 @@ jobs:
     #  jdk: openjdk13
 
 
-    - name: "openjdk@8 on macOS xcode11.6"
-      os: osx
-      osx_image: xcode11.6  # Supports homebrew bundle without needing update
-      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-      # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
-      addons:
-        homebrew:
-          taps:
-            - homebrew/cask-versions # for openjdk
-          packages:
-            - ant
-            - openjdk@8
-      before_install:
-        # Probe the brew Cellar
-        - brew --prefix
-        - brew list openjdk@8
-        # Make available to the JDK switcher.
-        # See: https://formulae.brew.sh/formula/openjdk@8
-        - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
-            /Library/Java/JavaVirtualMachines/openjdk-8.jdk
-        # Add the required JDK to the path
-        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
+    #- name: "openjdk@8 on macOS xcode11.6"
+    #  os: osx
+    #  osx_image: xcode11.6  # Supports homebrew bundle without needing update
+    #  # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
+    #  # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
+    #  addons:
+    #    homebrew:
+    #      taps:
+    #        - homebrew/cask-versions # for openjdk
+    #      packages:
+    #        - ant
+    #        - openjdk@8
+    #  before_install:
+    #    # Probe the brew Cellar
+    #    - brew --prefix
+    #    - brew list openjdk@8
+    #    # Make available to the JDK switcher.
+    #    # See: https://formulae.brew.sh/formula/openjdk@8
+    #    - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
+    #        /Library/Java/JavaVirtualMachines/openjdk-8.jdk
+    #    # Add the required JDK to the path
+    #    - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
+    #    - echo $JAVA_HOME
+    #    - export PATH="$JAVA_HOME/bin:$PATH"
 
 
     - name: "openjdk11 on Windows"
@@ -68,13 +68,18 @@ jobs:
         # Install the required JDK and ant
         - choco install openjdk11 ant
         # Only a new sub-shell knows where Chocolatey put Ant
-        - ant_exe=$(powershell -c '(Get-Command ant).Path')
+        - powershell -NonInteractive -Command  '[Environment]::GetEnvironmentVariable("PATH","Machine")'
+        - powershell -NonInteractive -Command  '[Environment]::GetEnvironmentVariable("PATH","User")'
+        - powershell -NonInteractive -Command  'ant -version'
+        - ant_exe=$(powershell -NonInteractive -Command  '(Get-Command ant).Path')
         - echo $ant_exe
         - echo ${ant_exe%\\*}
         - export ANT_BIN=$(cygpath "${ant_exe%\\*}")
         - echo $ANT_BIN
         # Only a new sub-shell knows where Chocolatey put Java
-        - java_exe=$(powershell -c '(Get-Command java).Path')
+        - powershell -NonInteractive -Command  'java -version'
+        - powershell -NonInteractive -Command  'Get-Command java'
+        - java_exe=$(powershell -NonInteractive -Command  '(Get-Command java).Path')
         - echo $java_exe
         - echo ${java_exe%\\bin\\*}
         - export JAVA_HOME=$(cygpath "${java_exe%\\bin\\*}")

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ jobs:
     - name: "openjdk11 on Linux"
       jdk: openjdk11
 
-    - name: "openjdk13 on Linux"
-      jdk: openjdk13
+    #- name: "openjdk13 on Linux"
+    #  jdk: openjdk13
 
     - name: "openjdk8 on macOS"
       os: osx
@@ -50,19 +50,19 @@ jobs:
       os: windows
       language: shell  # Travis CI Windows does not yet support language: java
       env:
-        - JAVA_HOME="/c/Program Files/AdoptOpenJDK/jdk-11.0.8.10-hotspot"
-        - ANT_HOME="/c/Users/travis/apache-ant"
-        - PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+        - echo $PATH
       before_install:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK (must match JAVA_HOME in env: section)
-        - choco install adoptopenjdk11
-        - ls "/c/Program Files/AdoptOpenJDK" # Check JAVA_HOME is correct :(
-        # Install ant at $ANT_HOME (chosen in env: section)
-        - curl https://downloads.apache.org/ant/binaries/apache-ant-1.10.8-bin.zip -o apache-ant.zip
-        - unzip -q apache-ant.zip
-        - rm apache-ant.zip
-        - mv apache-ant-1.10.8 $ANT_HOME
+        - choco install ojdkbuild11
+        - choco install ant
+        # Confidence checks
+        - which java
+        - which javac
+        - which ant
+         #- JAVA_HOME="/c/Program Files/AdoptOpenJDK/jdk-11.0.8.10-hotspot"
+        #- ANT_HOME="/c/Users/travis/apache-ant"
+        #- PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"
     #  language: python  # lint Python code for syntax errors and undefined names
@@ -83,5 +83,10 @@ install:
   - ant developer-build
 
 # Run the regression test (tweaked for Travis in build.xml)
-script:  ant regrtest-travis
+script:
+    # Disabled for now: only report environment
+    ant dump-env
+    dist/bin/jython -V
+    # Fairly full regression test
+    #ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ jobs:
         - echo $posh_path
         #- export PATH="$posh_path"
         # Can we get JAVA_HOME this way too?
-        - powershell -NonInteractive -Command  'Get-Command java'
-        - java_exe=$(powershell -NonInteractive -Command  'RefreshEnv; write((Get-Command java).Path)')
+        - powershell -NonInteractive -Command  'RefreshEnv; Get-Command java'
+        - java_exe=$(powershell -NonInteractive -Command 'RefreshEnv; write((Get-Command java).Path)')
         - echo $java_exe
         - java_exe=$(cygpath "$java_exe")
         - echo $java_exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ addons:
 
   hostname: jyshort
 
-  
+
 jobs:
   include:
     - name: "openjdk8 on Linux"
       dist: xenial
       jdk: openjdk8
 
-    - name: "openjdk11 on Linux"
-      jdk: openjdk11
+    #- name: "openjdk11 on Linux"
+    #  jdk: openjdk11
 
     #- name: "openjdk13 on Linux"
     #  jdk: openjdk13
@@ -35,9 +35,9 @@ jobs:
           taps:
             # - AdoptOpenJDK/openjdk # for java
             # but see https://github.com/AdoptOpenJDK/homebrew-openjdk/issues/106
-            - homebrew/cask-versions # ant & jdk 8
-          casks:
-            - adoptopenjdk8
+            - homebrew/cask-versions # ant ##& jdk 8
+          #casks:
+          #  - adoptopenjdk8
           packages:
             - ant
       before_install:
@@ -50,19 +50,14 @@ jobs:
       os: windows
       language: bash  # Travis CI Windows does not yet support language: java
       env:
-        - echo $PATH
+        #- JAVA_HOME="/c/Program Files/AdoptOpenJDK/jdk-11.0.8.10-hotspot"
+        #- ANT_HOME="/c/Users/travis/apache-ant"
+        #- PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
       before_install:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK (must match JAVA_HOME in env: section)
         - choco install ojdkbuild11
         - choco install ant
-        # Confidence checks
-        - which java
-        - which javac
-        - which ant
-         #- JAVA_HOME="/c/Program Files/AdoptOpenJDK/jdk-11.0.8.10-hotspot"
-        #- ANT_HOME="/c/Users/travis/apache-ant"
-        #- PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"
     #  language: python  # lint Python code for syntax errors and undefined names
@@ -77,9 +72,13 @@ jobs:
 # Install (i.e. build) Jython
 install:
   # Confirm versions and paths (this has been a problem)
+  - which java
+  - which javac
+  - which ant
   - echo $PATH
   - java -version
   - ant -version
+  # Build Jython
   - ant developer-build
 
 # Run the regression test (tweaked for Travis in build.xml)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
-# https://docs.travis-ci.com/user/languages/java/
-# https://docs.travis-ci.com/user/reference/osx/
-# https://docs.travis-ci.com/user/reference/windows/
+# Build and run regression tests at Travis CI
+#
+# Sections of this are commented out principally for economy in running the tests.
+# Runs are about 20 minutes on each host.
+#
 os: linux
 dist: focal
 language: java
-
-# Put these in env global in the hope of getting before addons.homebrew
-env:
-  global:
-    - HOMEBREW_NO_AUTO_UPDATE=1
-    - HOMEBREW_NO_INSTALL_CLEANUP=1
 
 
 addons:
@@ -23,72 +19,60 @@ addons:
 jobs:
   include:
 
-    # Disable everything but the OSX build
-    #- name: "openjdk8 on Linux"
-    #  dist: xenial
-    #  jdk: openjdk8
+    - name: "openjdk8 on Linux"
+      dist: xenial
+      jdk: openjdk8
 
 
-    #- name: "openjdk11 on Linux"
-    #  jdk: openjdk11
+    - name: "openjdk11 on Linux"
+      jdk: openjdk11
 
 
-    #- name: "openjdk13 on Linux"
-    #  jdk: openjdk13
-
-    - name: "openjdk@8 on macOS xcode11.6"
-      os: osx
-      osx_image: xcode11.6  # Supports homebrew bundle without needing update
-      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-      # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
-      addons:
-        homebrew:
-          taps:
-            - homebrew/cask-versions # for openjdk
-          packages:
-            - ant
-            - openjdk@8
-      before_install:
-        # Probe the brew Cellar
-        - brew list openjdk@8
-        # Make available to the JDK switcher.
-        # See: https://formulae.brew.sh/formula/openjdk@8
-        - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
-            /Library/Java/JavaVirtualMachines/openjdk-8.jdk
-        # Add the required JDK to the path
-        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
-
-
-    #- name: "openjdk11 on Windows"
-    #  os: windows
-    #  language: bash  # Travis CI Windows does not yet support language: java
-
+    ####
+    # OSX disabled because the homebrew installation of Java 8 takes nearly 20 minutes.
+    # (It seems impossible to stop it doing a "brew update".)
+    ####
+    #- name: "openjdk@8 on macOS xcode11.6"
+    #  os: osx
+    #  osx_image: xcode11.6  # Supports homebrew bundle without needing update
+    #  # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
+    #  addons:
+    #    homebrew:
+    #      taps:
+    #        - homebrew/cask-versions # for openjdk
+    #      packages:
+    #        - ant
+    #        - openjdk@8
     #  before_install:
-    #    - pwd # /c/Users/travis/build/<github-user>/<repo-name>
-    #    # Install the required JDK and ant
-    #    - choco install openjdk11 ant
-
-    #    # Ant is installed on the (bash) PATH at /c/ProgramData/chocolatey/bin.
-    #    # Java is at /c/Program Files/OpenJDK/openjdk-<version-patch>/bin which is liable to change.
-    #    # Chocolatey has updated the PATH for Java, but only in powershell [Environment].
-    #    # Dig out the Java path from [Environment] and translate it to Unix.
-    #    - java_exe=$(powershell -NonInteractive -Command
-    #        '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
-    #            write((Get-Command java).Path)')
-    #    - java_exe=$(cygpath "$java_exe")
-    #    - echo $java_exe
-    #    - export JAVA_HOME="${java_exe%/bin/*}"
+    #    # Probe the brew Cellar
+    #    - brew list openjdk@8
+    #    # Make available to the JDK switcher.
+    #    - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
+    #        /Library/Java/JavaVirtualMachines/openjdk-8.jdk
+    #    # Add the required JDK to the path
+    #    - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
     #    - echo $JAVA_HOME
     #    - export PATH="$JAVA_HOME/bin:$PATH"
 
 
-    #- name: "Lint Python 2 code for syntax errors and undefined names"
-    #  language: python  # lint Python code for syntax errors and undefined names
-    #  python: 2.7
-    #  install: pip install flake8
-    #  script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: "openjdk11 on Windows"
+      os: windows
+      language: bash  # Travis CI Windows does not yet support language: java
+
+      before_install:
+        # Install the required JDK and ant
+        - choco install openjdk11 ant
+        # Java is at /c/Program Files/OpenJDK/openjdk-<version-patch>/bin which is liable to change.
+        # Chocolatey has updated the PATH with that, but only in powershell [Environment].
+        # Dig out the Java path from [Environment] and translate it to Unix.
+        - java_exe=$(powershell -NonInteractive -Command
+            '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
+                write((Get-Command java).Path)')
+        - java_exe=$(cygpath "$java_exe")
+        - echo $java_exe
+        - export JAVA_HOME="${java_exe%/bin/*}"
+        - export PATH="$JAVA_HOME/bin:$PATH"
+
 
   allow_failures:
     - language: python
@@ -104,7 +88,6 @@ install:
     # Confirm versions and paths (this has been a problem)
     - echo $PATH
     - echo $JAVA_HOME
-    - java -version
     - ant -version
     # Build Jython
     - ant developer-build
@@ -112,9 +95,8 @@ install:
 
 # Run the regression test (tweaked for Travis in build.xml)
 script:
-    # Disabled for now: only report version (includes Java version)
+    # Echo versions of Jython, Java and OS
     - ant -emacs versions
-    #- ant dump-env
     # Fairly full regression test
     #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 # Run the regression test (tweaked for Travis in build.xml)
 script:
     # Echo versions of Jython, Java and OS
-    - ant -emacs versions
+    #- ant -emacs versions
     # Fairly full regression test
-    #- ant regrtest-travis
+    - ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ os: linux
 dist: focal
 language: java
 
-# Put these up front in the hope of getting before addons.homebrew
-before_install:
-  - export HOMEBREW_NO_AUTO_UPDATE=1
-  - export HOMEBREW_NO_INSTALL_CLEANUP=1
+# Put these in env global in the hope of getting before addons.homebrew
+env:
+  global:
+    - HOMEBREW_NO_AUTO_UPDATE=1
+    - HOMEBREW_NO_INSTALL_CLEANUP=1
 
 
 addons:
@@ -106,13 +107,14 @@ install:
     - java -version
     - ant -version
     # Build Jython
-    #- ant developer-build
+    - ant developer-build
 
 
 # Run the regression test (tweaked for Travis in build.xml)
 script:
     # Disabled for now: only report version (includes Java version)
-    #- ant -emacs versions
+    - ant -emacs versions
+    #- ant dump-env
     # Fairly full regression test
     #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ os: linux
 dist: focal
 language: java
 
+# Put these up front in the hope of getting before addons.homebrew
+before_install:
+  - export HOMEBREW_NO_AUTO_UPDATE=1
+  - export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+
 addons:
   apt:  # only active on Linux
     packages:
@@ -16,13 +22,14 @@ addons:
 jobs:
   include:
 
-    - name: "openjdk8 on Linux"
-      dist: xenial
-      jdk: openjdk8
+    # Disable everything but the OSX build
+    #- name: "openjdk8 on Linux"
+    #  dist: xenial
+    #  jdk: openjdk8
 
 
-    - name: "openjdk11 on Linux"
-      jdk: openjdk11
+    #- name: "openjdk11 on Linux"
+    #  jdk: openjdk11
 
 
     #- name: "openjdk13 on Linux"
@@ -41,7 +48,6 @@ jobs:
             - ant
             - openjdk@8
       before_install:
-        - export HOMEBREW_NO_AUTO_UPDATE=1
         # Probe the brew Cellar
         - brew list openjdk@8
         # Make available to the JDK switcher.
@@ -54,27 +60,27 @@ jobs:
         - export PATH="$JAVA_HOME/bin:$PATH"
 
 
-    - name: "openjdk11 on Windows"
-      os: windows
-      language: bash  # Travis CI Windows does not yet support language: java
+    #- name: "openjdk11 on Windows"
+    #  os: windows
+    #  language: bash  # Travis CI Windows does not yet support language: java
 
-      before_install:
-        - pwd # /c/Users/travis/build/<github-user>/<repo-name>
-        # Install the required JDK and ant
-        - choco install openjdk11 ant
+    #  before_install:
+    #    - pwd # /c/Users/travis/build/<github-user>/<repo-name>
+    #    # Install the required JDK and ant
+    #    - choco install openjdk11 ant
 
-        # Ant is installed on the (bash) PATH at /c/ProgramData/chocolatey/bin.
-        # Java is at /c/Program Files/OpenJDK/openjdk-<version-patch>/bin which is liable to change.
-        # Chocolatey has updated the PATH for Java, but only in powershell [Environment].
-        # Dig out the Java path from [Environment] and translate it to Unix.
-        - java_exe=$(powershell -NonInteractive -Command
-            '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
-                write((Get-Command java).Path)')
-        - java_exe=$(cygpath "$java_exe")
-        - echo $java_exe
-        - export JAVA_HOME="${java_exe%/bin/*}"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
+    #    # Ant is installed on the (bash) PATH at /c/ProgramData/chocolatey/bin.
+    #    # Java is at /c/Program Files/OpenJDK/openjdk-<version-patch>/bin which is liable to change.
+    #    # Chocolatey has updated the PATH for Java, but only in powershell [Environment].
+    #    # Dig out the Java path from [Environment] and translate it to Unix.
+    #    - java_exe=$(powershell -NonInteractive -Command
+    #        '$env:PATH=[Environment]::GetEnvironmentVariable("PATH","Machine");
+    #            write((Get-Command java).Path)')
+    #    - java_exe=$(cygpath "$java_exe")
+    #    - echo $java_exe
+    #    - export JAVA_HOME="${java_exe%/bin/*}"
+    #    - echo $JAVA_HOME
+    #    - export PATH="$JAVA_HOME/bin:$PATH"
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"
@@ -100,13 +106,13 @@ install:
     - java -version
     - ant -version
     # Build Jython
-    - ant developer-build
+    #- ant developer-build
 
 
 # Run the regression test (tweaked for Travis in build.xml)
 script:
     # Disabled for now: only report version (includes Java version)
-    - ant -emacs versions
+    #- ant -emacs versions
     # Fairly full regression test
     #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ jobs:
       before_install:
         # Probe the brew Cellar
         - brew --prefix
-        - brew list ant
         - brew list openjdk@8
         # Make available to the JDK switcher.
         # See: https://formulae.brew.sh/formula/openjdk@8
@@ -69,19 +68,19 @@ jobs:
         # Install the required JDK and ant
         - choco install openjdk11 ant
         # Only a new sub-shell knows where Chocolatey put Ant
-        ant_exe=$(powershell -c '(Get-Command ant).Path')
-        echo $ant_exe
-        echo ${ant_exe%\\*}
-        export ANT_BIN=$(cygpath "${ant_exe%\\*}")
-        echo $ANT_BIN
+        - ant_exe=$(powershell -c '(Get-Command ant).Path')
+        - echo $ant_exe
+        - echo ${ant_exe%\\*}
+        - export ANT_BIN=$(cygpath "${ant_exe%\\*}")
+        - echo $ANT_BIN
         # Only a new sub-shell knows where Chocolatey put Java
-        java_exe=$(powershell -c '(Get-Command java).Path')
-        echo $java_exe
-        echo ${java_exe%\\bin\\*}
-        export JAVA_HOME=$(cygpath "${java_exe%\\bin\\*}")
-        echo $JAVA_HOME
+        - java_exe=$(powershell -c '(Get-Command java).Path')
+        - echo $java_exe
+        - echo ${java_exe%\\bin\\*}
+        - export JAVA_HOME=$(cygpath "${java_exe%\\bin\\*}")
+        - echo $JAVA_HOME
         # Now stitch together the path
-        export PATH="$JAVA_HOME"/bin:"$ANT_BIN":"$PATH"
+        - export PATH="$JAVA_HOME"/bin:"$ANT_BIN":"$PATH"
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ jobs:
         # Dig out the path from [Environment] and translate it to Unix
         - posh_path=$(powershell -NonInteractive -Command
             'write(([Environment]::GetEnvironmentVariable("PATH","Machine") + ";" +
-                    [Environment]::GetEnvironmentVariable("PATH","User"))
-                .replace("\","/").replace("C:","/c").replace(";",":"))')
+                    [Environment]::GetEnvironmentVariable("PATH","User")
+                ).replace("\","/").replace("C:","/c").replace(";",":"))')
         - echo $posh_path
         - export PATH="$posh_path"
         # Can we get JAVA_HOME this way too?

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,29 +15,33 @@ addons:
 
 jobs:
   include:
+
     - name: "openjdk8 on Linux"
       dist: xenial
       jdk: openjdk8
 
+
     #- name: "openjdk11 on Linux"
     #  jdk: openjdk11
+
 
     #- name: "openjdk13 on Linux"
     #  jdk: openjdk13
 
-    - name: "openjdk8 on macOS"
+
+    - name: "java8 on macOS xcode11.6"
       os: osx
       osx_image: xcode11.6  # Supports homebrew bundle without needing update
       # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
       # https://docs.travis-ci.com/user/installing-dependencies/
       addons:
         homebrew:
+          # https://docs.travis-ci.com/user/installing-dependencies/#installing-from-taps
           taps:
-            # - AdoptOpenJDK/openjdk # for java
             # but see https://github.com/AdoptOpenJDK/homebrew-openjdk/issues/106
-            - homebrew/cask-versions # ant ##& jdk 8
-          #casks:
-          #  - adoptopenjdk8
+            - homebrew/cask-versions # ant & jdk 8
+          casks:
+            - java8
           packages:
             - ant
       before_install:
@@ -45,6 +49,28 @@ jobs:
         - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
         - echo $JAVA_HOME
         - export PATH="$JAVA_HOME/bin:$PATH"
+
+
+    - name: "openjdk8 on macOS xcode9.3"
+      os: osx
+      osx_image: xcode9.3  # Runs java 8 out of the box
+      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
+      # https://docs.travis-ci.com/user/installing-dependencies/
+      addons:
+        homebrew:
+          # https://docs.travis-ci.com/user/installing-dependencies/#installing-from-taps
+          taps:
+            - homebrew/cask-versions # ant
+          casks:
+            - adoptopenjdk8
+          packages:
+            - ant
+      before_install:
+        # Add the required JDK to the path
+        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
+        - echo $JAVA_HOME
+        - export PATH="$JAVA_HOME/bin:$PATH"
+
 
     - name: "openjdk11 on Windows"
       os: windows
@@ -59,6 +85,7 @@ jobs:
         - choco install ojdkbuild11
         - choco install ant
 
+
     #- name: "Lint Python 2 code for syntax errors and undefined names"
     #  language: python  # lint Python code for syntax errors and undefined names
     #  python: 2.7
@@ -72,9 +99,6 @@ jobs:
 # Install (i.e. build) Jython
 install:
   # Confirm versions and paths (this has been a problem)
-  - which java
-  - which javac
-  - which ant
   - echo $PATH
   - java -version
   - ant -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,26 +46,6 @@ jobs:
         - echo $JAVA_HOME
         - export PATH="$JAVA_HOME/bin:$PATH"
 
-    - name: "openjdk11 on macOS"
-      os: osx
-      osx_image: xcode11.6  # Supports homebrew bundle without update
-      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-      # https://docs.travis-ci.com/user/installing-dependencies/
-      addons:
-        homebrew:
-          taps:
-            - AdoptOpenJDK/openjdk    # for java
-            - homebrew/cask-versions  # for ant
-          casks:
-            - adoptopenjdk11
-          packages:
-            - ant
-      before_install:
-        # Add the required JDK to the path
-        - export JAVA_HOME="$(/usr/libexec/java_home -v11)"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
-
     - name: "openjdk11 on Windows"
       os: windows
       language: shell  # Travis CI Windows does not yet support language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,11 @@ jobs:
       # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
       addons:
         homebrew:
+          taps:
+            - homebrew/cask-core # for openjdk
           casks:
             - openjdk@8
           packages:
-            # Does this work without taps: homebrew/cask-versions
             - ant
       before_install:
         # Make available to the JDK switcher.
@@ -52,30 +53,11 @@ jobs:
         - export PATH="$JAVA_HOME/bin:$PATH"
 
 
-    - name: "default Java 8 on macOS xcode9.3"
-      os: osx
-      osx_image: xcode9.3  # Runs Java 8 out of the box
-      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-      # https://docs.travis-ci.com/user/installing-dependencies/
-      addons:
-        homebrew:
-          # https://docs.travis-ci.com/user/installing-dependencies/#installing-from-taps
-          taps:
-            - homebrew/cask-versions # ant
-          packages:
-            - ant
-      before_install:
-        # Add the required JDK to the path
-        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
-
-
     - name: "openjdk11 on Windows"
       os: windows
       language: bash  # Travis CI Windows does not yet support language: java
       env:
-      # Control installation locations (see also before_install: section)
+        # Control installation locations (see also before_install: section)
         - JAVA_HOME="/c/Users/travis/build/jdk"
         - ANT_HOME="/c/Users/travis/build/ant"
         - PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
@@ -85,14 +67,12 @@ jobs:
         - cygpath -w "$JAVA_HOME"
         - java_home=$(cygpath -w "$JAVA_HOME")
         - echo "$java_home"
-        - choco install openjdk11 -params installdir="$(cygpath -w $JAVA_HOME)"
-        - java -version
+        - choco install openjdk11 -params "installdir=$(cygpath -w $JAVA_HOME)" -y
         # Install the required Ant (at variables in env: section)
         - cygpath -w $ANT_HOME
         - ant_home=$(cygpath -w "$ANT_HOME")
         - echo "$ant_home"
-        - choco install ant -params installdir="$ant_home"
-        - ant -version
+        - choco install ant -params "installdir=$ant_home" -y
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"
@@ -105,20 +85,26 @@ jobs:
     - language: python
     - os: osx # remains flakey
 
+#
+# Common part to all hosts
+#
+
 # Install (i.e. build) Jython
 install:
-  # Confirm versions and paths (this has been a problem)
-  - echo $PATH
-  - java -version
-  - ant -version
-  # Build Jython
-  - ant developer-build
+    # Confirm versions and paths (this has been a problem)
+    - echo $PATH
+    - echo $JAVA_HOME
+    - java -version
+    - ant -version
+    # Build Jython
+    #- ant developer-build
+    #- dist/bin/jython -V
+
 
 # Run the regression test (tweaked for Travis in build.xml)
 script:
     # Disabled for now: only report environment
     - ant dump-env
-    - dist/bin/jython -V
     # Fairly full regression test
     #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,29 +29,30 @@ jobs:
     #  jdk: openjdk13
 
 
-    - name: "openjdk@8 on macOS xcode11.6"
-      os: osx
-      osx_image: xcode11.6  # Supports homebrew bundle without needing update
-      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-      # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
-      addons:
-        homebrew:
-          taps:
-            - homebrew/cask-versions # for openjdk
-          packages:
-            - ant
-            - openjdk@8
-      before_install:
-        # Probe the brew Cellar
-        - brew list openjdk@8
-        # Make available to the JDK switcher.
-        # See: https://formulae.brew.sh/formula/openjdk@8
-        - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
-            /Library/Java/JavaVirtualMachines/openjdk-8.jdk
-        # Add the required JDK to the path
-        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
-        - echo $JAVA_HOME
-        - export PATH="$JAVA_HOME/bin:$PATH"
+    ## OSX disabled because it is expensive (and currently fails anyway)
+    #- name: "openjdk@8 on macOS xcode11.6"
+    #  os: osx
+    #  osx_image: xcode11.6  # Supports homebrew bundle without needing update
+    #  # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
+    #  # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
+    #  addons:
+    #    homebrew:
+    #      taps:
+    #        - homebrew/cask-versions # for openjdk
+    #      packages:
+    #        - ant
+    #        - openjdk@8
+    #  before_install:
+    #    # Probe the brew Cellar
+    #    - brew list openjdk@8
+    #    # Make available to the JDK switcher.
+    #    # See: https://formulae.brew.sh/formula/openjdk@8
+    #    - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
+    #        /Library/Java/JavaVirtualMachines/openjdk-8.jdk
+    #    # Add the required JDK to the path
+    #    - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
+    #    - echo $JAVA_HOME
+    #    - export PATH="$JAVA_HOME/bin:$PATH"
 
 
     - name: "openjdk11 on Windows"
@@ -106,7 +107,7 @@ install:
 # Run the regression test (tweaked for Travis in build.xml)
 script:
     # Disabled for now: only report version (includes Java version)
-    - dist/bin/jython -V
+    - ant -emacs versions
     # Fairly full regression test
     #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,34 +58,24 @@ jobs:
     - name: "openjdk11 on Windows"
       os: windows
       language: bash  # Travis CI Windows does not yet support language: java
-      env:
-        # Installation locations? (see also before_install: section)
-        #- JAVA_HOME="/c/Users/travis/build/jdk"
-        #- ANT_HOME="/c/Users/travis/build/ant"
-        #- PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
       before_install:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK and ant
         - choco install openjdk11 ant
-        # Only a new sub-shell knows where Chocolatey put Ant
-        - powershell -NonInteractive -Command  '[Environment]::GetEnvironmentVariable("PATH","Machine")'
-        - powershell -NonInteractive -Command  '[Environment]::GetEnvironmentVariable("PATH","User")'
-        - powershell -NonInteractive -Command  'ant -version'
-        - ant_exe=$(powershell -NonInteractive -Command  '(Get-Command ant).Path')
-        - echo $ant_exe
-        - echo ${ant_exe%\\*}
-        - export ANT_BIN=$(cygpath "${ant_exe%\\*}")
-        - echo $ANT_BIN
-        # Only a new sub-shell knows where Chocolatey put Java
-        - powershell -NonInteractive -Command  'java -version'
+        - ls -l /c/ProgramData/chocolatey/bin
+        # Chocolatey has updated the PATH, but only for a new powershell
+        # Dig out the path and translate it to Unix
+        - posh_path=$(powershell -NonInteractive -Command
+            'write($env:PATH.replace("\","/").replace("C:","/c").replace(";",":"))')
+        - echo $posh_path
+        - export PATH="$posh_path"
+        # Can we get JAVA_HOME this way too?
         - powershell -NonInteractive -Command  'Get-Command java'
         - java_exe=$(powershell -NonInteractive -Command  '(Get-Command java).Path')
         - echo $java_exe
         - echo ${java_exe%\\bin\\*}
         - export JAVA_HOME=$(cygpath "${java_exe%\\bin\\*}")
         - echo $JAVA_HOME
-        # Now stitch together the path
-        - export PATH="$JAVA_HOME"/bin:"$ANT_BIN":"$PATH"
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,31 +28,30 @@ jobs:
     #- name: "openjdk13 on Linux"
     #  jdk: openjdk13
 
-
-    ## OSX disabled because it is expensive (and currently fails anyway)
-    #- name: "openjdk@8 on macOS xcode11.6"
-    #  os: osx
-    #  osx_image: xcode11.6  # Supports homebrew bundle without needing update
-    #  # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-    #  # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
-    #  addons:
-    #    homebrew:
-    #      taps:
-    #        - homebrew/cask-versions # for openjdk
-    #      packages:
-    #        - ant
-    #        - openjdk@8
-    #  before_install:
-    #    # Probe the brew Cellar
-    #    - brew list openjdk@8
-    #    # Make available to the JDK switcher.
-    #    # See: https://formulae.brew.sh/formula/openjdk@8
-    #    - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
-    #        /Library/Java/JavaVirtualMachines/openjdk-8.jdk
-    #    # Add the required JDK to the path
-    #    - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
-    #    - echo $JAVA_HOME
-    #    - export PATH="$JAVA_HOME/bin:$PATH"
+    - name: "openjdk@8 on macOS xcode11.6"
+      os: osx
+      osx_image: xcode11.6  # Supports homebrew bundle without needing update
+      # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
+      # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
+      addons:
+        homebrew:
+          update: false
+          taps:
+            - homebrew/cask-versions # for openjdk
+          packages:
+            - ant
+            - openjdk@8
+      before_install:
+        # Probe the brew Cellar
+        - brew list openjdk@8
+        # Make available to the JDK switcher.
+        # See: https://formulae.brew.sh/formula/openjdk@8
+        - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
+            /Library/Java/JavaVirtualMachines/openjdk-8.jdk
+        # Add the required JDK to the path
+        - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
+        - echo $JAVA_HOME
+        - export PATH="$JAVA_HOME/bin:$PATH"
 
 
     - name: "openjdk11 on Windows"

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,12 +68,20 @@ jobs:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
         # Install the required JDK and ant
         - choco install openjdk11 ant
-        - tail --lines=200 /c/ProgramData/chocolatey/logs/chocolatey.log
-        - ls -l /c/ProgramData/chocolatey/lib/ant/tools
-        - ls -l "/c/Program Files/OpenJDK"
-        # Does this access the new path?
-        - bash -c 'echo $JAVA_HOME'
-        - bash -c 'echo $PATH'
+        # Only a new sub-shell knows where Chocolatey put Ant
+        ant_exe=$(powershell -c '(Get-Command ant).Path')
+        echo $ant_exe
+        echo ${ant_exe%\\*}
+        export ANT_BIN=$(cygpath "${ant_exe%\\*}")
+        echo $ANT_BIN
+        # Only a new sub-shell knows where Chocolatey put Java
+        java_exe=$(powershell -c '(Get-Command java).Path')
+        echo $java_exe
+        echo ${java_exe%\\bin\\*}
+        export JAVA_HOME=$(cygpath "${java_exe%\\bin\\*}")
+        echo $JAVA_HOME
+        # Now stitch together the path
+        export PATH="$JAVA_HOME"/bin:"$ANT_BIN":"$PATH"
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: "openjdk11 on Windows"
       os: windows
-      language: shell  # Travis CI Windows does not yet support language: java
+      language: bash  # Travis CI Windows does not yet support language: java
       env:
         - echo $PATH
       before_install:
@@ -85,8 +85,8 @@ install:
 # Run the regression test (tweaked for Travis in build.xml)
 script:
     # Disabled for now: only report environment
-    ant dump-env
-    dist/bin/jython -V
+    - ant dump-env
+    - dist/bin/jython -V
     # Fairly full regression test
-    #ant regrtest-travis
+    #- ant regrtest-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,14 +70,17 @@ jobs:
                     [Environment]::GetEnvironmentVariable("PATH","User")
                 ).replace("\","/").replace("C:","/c").replace(";",":"))')
         - echo $posh_path
-        - export PATH="$posh_path"
+        #- export PATH="$posh_path"
         # Can we get JAVA_HOME this way too?
         - powershell -NonInteractive -Command  'Get-Command java'
-        - java_exe=$(powershell -NonInteractive -Command  '(Get-Command java).Path')
+        - java_exe=$(powershell -NonInteractive -Command  'RefreshEnv; write((Get-Command java).Path)')
         - echo $java_exe
-        - echo ${java_exe%\\bin\\*}
-        - export JAVA_HOME=$(cygpath "${java_exe%\\bin\\*}")
+        - java_exe=$(cygpath "$java_exe")
+        - echo $java_exe
+        - echo ${java_exe%/bin/*}
+        - export JAVA_HOME="${java_exe%/bin/*}"
         - echo $JAVA_HOME
+        - export PATH="$JAVA_HOME/bin:$PATH"
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ addons:
 jobs:
   include:
 
-    - name: "openjdk8 on Linux"
-      dist: xenial
-      jdk: openjdk8
+    #- name: "openjdk8 on Linux"
+    #  dist: xenial
+    #  jdk: openjdk8
 
 
     #- name: "openjdk11 on Linux"
@@ -29,31 +29,32 @@ jobs:
     #  jdk: openjdk13
 
 
-    - name: "java8 on macOS xcode11.6"
+    - name: "openjdk@8 on macOS xcode11.6"
       os: osx
       osx_image: xcode11.6  # Supports homebrew bundle without needing update
       # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
-      # https://docs.travis-ci.com/user/installing-dependencies/
+      # https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos
       addons:
         homebrew:
-          # https://docs.travis-ci.com/user/installing-dependencies/#installing-from-taps
-          taps:
-            # but see https://github.com/AdoptOpenJDK/homebrew-openjdk/issues/106
-            - homebrew/cask-versions # ant & jdk 8
           casks:
-            - java8
+            - openjdk@8
           packages:
+            # Does this work without taps: homebrew/cask-versions
             - ant
       before_install:
+        # Make available to the JDK switcher.
+        # See: https://formulae.brew.sh/formula/openjdk@8
+        - sudo ln -sfn $(brew --prefix)/opt/openjdk@8/libexec/openjdk.jdk
+            /Library/Java/JavaVirtualMachines/openjdk-8.jdk
         # Add the required JDK to the path
         - export JAVA_HOME="$(/usr/libexec/java_home -v1.8)"
         - echo $JAVA_HOME
         - export PATH="$JAVA_HOME/bin:$PATH"
 
 
-    - name: "openjdk8 on macOS xcode9.3"
+    - name: "default Java 8 on macOS xcode9.3"
       os: osx
-      osx_image: xcode9.3  # Runs java 8 out of the box
+      osx_image: xcode9.3  # Runs Java 8 out of the box
       # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/26
       # https://docs.travis-ci.com/user/installing-dependencies/
       addons:
@@ -61,8 +62,6 @@ jobs:
           # https://docs.travis-ci.com/user/installing-dependencies/#installing-from-taps
           taps:
             - homebrew/cask-versions # ant
-          casks:
-            - adoptopenjdk8
           packages:
             - ant
       before_install:
@@ -76,14 +75,24 @@ jobs:
       os: windows
       language: bash  # Travis CI Windows does not yet support language: java
       env:
-        #- JAVA_HOME="/c/Program Files/AdoptOpenJDK/jdk-11.0.8.10-hotspot"
-        #- ANT_HOME="/c/Users/travis/apache-ant"
-        #- PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+      # Control installation locations (see also before_install: section)
+        - JAVA_HOME="/c/Users/travis/build/jdk"
+        - ANT_HOME="/c/Users/travis/build/ant"
+        - PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
       before_install:
         - pwd # /c/Users/travis/build/<github-user>/<repo-name>
-        # Install the required JDK (must match JAVA_HOME in env: section)
-        - choco install ojdkbuild11
-        - choco install ant
+        # Install the required JDK (at variables in env: section)
+        - cygpath -w "$JAVA_HOME"
+        - java_home=$(cygpath -w "$JAVA_HOME")
+        - echo "$java_home"
+        - choco install openjdk11 -params installdir="$(cygpath -w $JAVA_HOME)"
+        - java -version
+        # Install the required Ant (at variables in env: section)
+        - cygpath -w $ANT_HOME
+        - ant_home=$(cygpath -w "$ANT_HOME")
+        - echo "$ant_home"
+        - choco install ant -params installdir="$ant_home"
+        - ant -version
 
 
     #- name: "Lint Python 2 code for syntax errors and undefined names"

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -180,6 +180,8 @@ class ThreadedNetworkedTestsSSL(BaseThreadedNetworkedTests):
     imap_class = IMAP4_SSL
 
 
+@unittest.skipIf(is_jython, "Failing on Jython issue gh-126")
+# https://github.com/jython/jython/issues/126
 class RemoteIMAPTest(unittest.TestCase):
     host = 'cyrus.andrew.cmu.edu'
     port = 143

--- a/build.xml
+++ b/build.xml
@@ -1369,6 +1369,25 @@ The text for an official release would continue like ...
       </exec>
     </target>
 
+    <target name="versions" depends="init, versions-unix, versions-windows"
+        description="identify the versions of Jython and its platform (needs developer-build)"/>
+
+    <target name="versions-unix" if="os.family.unix">
+        <exec executable="${dist.dir}/bin/jython">
+            <env key="JAVA_OPTS" value="-Duser.language=en -Duser.region=US"/>
+            <arg value="-c"/>
+            <arg value="import sys, platform; print sys.version; print platform.java_ver()"/>
+        </exec>
+    </target>
+
+    <target name="versions-windows" if="os.family.windows">
+        <mkdir dir="${junit.reports}"/>
+        <exec executable="${dist.dir}/bin/jython.exe">
+            <arg value="-c"/>
+            <arg value="import sys, platform; print sys.version; print platform.java_ver()"/>
+        </exec>
+    </target>
+
     <target name="regrtest" depends="developer-build, regrtest-unix, regrtest-windows"
         description="run Python tests expected to work on Jython"/>
 


### PR DESCRIPTION
This change gets the regression tests working again on Linux (Java 8 and 11) and Windows (Java 11).

Our CI facility stopped when travis-ci.org closed. I have migrated our build history to travis-ci.com and Travis have kindly given us some credit by way of support. It's not a huge amount (35000 credits), relative to the cost of each regression test (1200 credits) and so far it is a one-off, not a monthly allowance.

The idea was to do this before turning to contributor PRs last weekend, but it took much longer than I hoped.

I could not get the OSX build working satisfactorily because [it spends nigh-on 1000 credits before ever running a test](https://travis-ci.community/t/cannot-avoid-brew-update/12033/7). Travis have some [interesting platforms](https://docs.travis-ci.com/user/multi-cpu-architectures) available but GitHub actions may still be the way to go for routine tests.

**This PR absolutely needs a squash-commit.** It was a long journey of trial-and-error.
