### PR TITLE
Changes to PyArray item size fixing #119

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -76,7 +76,7 @@ class BaseTest(unittest.TestCase):
 
     def test_byteswap(self):
         if test_support.is_jython and self.typecode == 'u':
-            self.skipTest("Jython unicode byteswap not implemented")
+            self.skipTest("byteswap results in illegal characters")
         a = array.array(self.typecode, self.example)
         self.assertRaises(TypeError, a.byteswap, 42)
         if a.itemsize in (1, 2, 4, 8):
@@ -1040,13 +1040,7 @@ class UnsignedNumberTest(NumberTest):
         a = array.array(self.typecode)
         lower = 0
         itemsize = a.itemsize
-        if test_support.is_jython:
-            #  unsigned itemsizes are larger than would be expected
-            # in CPython because Jython promotes to the next size
-            # (Java has no unsiged integers except for char)
-            upper = long(pow(2, a.itemsize * 8 - 1)) - 1L
-        else:
-            upper = long(pow(2, a.itemsize * 8)) - 1L
+        upper = long(pow(2, a.itemsize * 8)) - 1L
         self.check_overflow(lower, upper)
 
 

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ For more details, three sources are available according to type:
 
 Jython 2.7.3a1
   Bugs fixed
+    - [ GH-119 ] array.array itemsize and serialization anomalies for unsigned types
     - [ GH-122 ] Upgrade Apache commons-compress to 1.21
     - [ GH-57 ] JavaWebStart compatibility broken
     - [ GH-35 ] Travis CI on JDKs 8, 11, 13 and add Windows to OSes
@@ -21,6 +22,14 @@ Jython 2.7.3a1
     - [ GH-2 ] Transfer closed-fixed issues in NEWS from frozen-mirror
 
   New Features
+
+    - array.array itemsize of unsigned types is now the same as their signed counterparts, where 
+      previously it was mostly double. Internal representations have changed. Anomalies have been
+      eliminated between itemsize and the serialisation (tostring() etc.) for unsigned types,
+      and in the range of values accepted in different contexts. The size of type 'u' (unicode
+      character) is 4 on all platforms. Client code that was working around these anomalies may
+      have to change. Overall, the experience should be closer to that with CPython.
+
     - The project has moved its home to GitHub (twice).
 
 Jython 2.7.2

--- a/src/org/python/core/PyArray.java
+++ b/src/org/python/core/PyArray.java
@@ -34,11 +34,11 @@ import org.python.modules.gc;
  * The range of possible element (item) types exceeds that in Python, since it allows for arbitrary
  * Java classes. This extended behaviour is accessible from Python by supplying a Java type (class)
  * to the constructor, where one might have used a single character type code. For example:<pre>
- * >>> ax = array.array(BigDecimal, (BigDecimal(str(n)) for n in range(5)))
- * >>> ax
+ * &gt;&gt;&gt; ax = array.array(BigDecimal, (BigDecimal(str(n)) for n in range(5)))
+ * &gt;&gt;&gt; ax
  * array(java.math.BigDecimal, [0, 1, 2, 3, 4])
- * >>> type(ax[2])
- * &lt;type 'java.math.BigDecimal'>
+ * &gt;&gt;&gt; type(ax[2])
+ * &lt;type 'java.math.BigDecimal'&gt;
  * </pre>
  *
  * <table>
@@ -222,7 +222,7 @@ public class PyArray extends PySequence implements Cloneable, BufferProtocol, Tr
      * @param itemClass when {@code itemType =} {@link ItemType#OBJECT}
      * @param initial provider of initial contents
      */
-    public PyArray(PyType subtype, ItemType itemType, Class<?> itemClass, PyObject initial) {
+    PyArray(PyType subtype, ItemType itemType, Class<?> itemClass, PyObject initial) {
         this(subtype, itemType, itemClass, 0);
         useInitial(initial);
     }
@@ -1150,8 +1150,8 @@ public class PyArray extends PySequence implements Cloneable, BufferProtocol, Tr
      * @param input string of bytes containing array data
      * @return number of primitives successfully read ({@code =count}, if not ended by EOF)
      */
-    public void fromstring(int start, String input) {
-        fromBytes(start, StringUtil.toBytes(input));
+    public int fromstring(int start, String input) {
+        return fromBytes(start, StringUtil.toBytes(input));
     }
 
     /**

--- a/src/org/python/core/PyObject.java
+++ b/src/org/python/core/PyObject.java
@@ -4123,7 +4123,7 @@ public class PyObject implements Serializable {
     }
 
     /**
-     * Convert this object longo an long. Throws a PyException on failure.
+     * Convert this object into a long. Throws a PyException on failure.
      *
      * @return an long value
      */

--- a/src/org/python/core/PyUnicode.java
+++ b/src/org/python/core/PyUnicode.java
@@ -101,10 +101,11 @@ public class PyUnicode extends PyString implements Iterable<Integer> {
      * @throws PyException(ValueError) if not a valid Unicode codepoint.
      */
     private static String checkedCPString(int codePoint) throws PyException {
-        try {
-            return Character.toString(codePoint);
-        } catch (IllegalArgumentException e) {
-            throw Py.ValueError(e.getMessage());
+        if (Character.isValidCodePoint(codePoint)) {
+            return new String(Character.toChars(codePoint));
+        } else {
+            throw Py.ValueError(
+                    String.format("character U+%08x is not in Unicode range", codePoint));
         }
     }
 

--- a/src/org/python/core/io/TextIOBase.java
+++ b/src/org/python/core/io/TextIOBase.java
@@ -11,7 +11,6 @@ import org.python.core.PyArray;
 import org.python.core.PyBUF;
 import org.python.core.PyBuffer;
 import org.python.core.PyObject;
-import org.python.core.PyString;
 
 /**
  * Base class for text I/O.
@@ -102,16 +101,11 @@ public abstract class TextIOBase extends IOBase {
      */
     public int readinto(PyObject buf) {
 
-        // This is an inefficient version of readinto: but readinto is
-        // not recommended for use in Python 2.x anyway
-
         if (buf instanceof PyArray) {
-            // PyArray has the buffer interface but it only works for bytes at present
-            PyArray array = (PyArray)buf;
-            String read = read(array.__len__());
-            for (int i = 0; i < read.length(); i++) {
-                array.set(i, new PyString(read.charAt(i)));
-            }
+            // PyArray has the buffer interface (for bytes) but this way we can read any type
+            PyArray array = (PyArray) buf;
+            String read = read(array.__len__() * array.getItemsize());
+            array.fromstring(0, read);
             return read.length();
 
         } else if (buf instanceof BufferProtocol) {


### PR DESCRIPTION
`PyArray` (up to this change) represents its several supported unsigned types by Java primitives wider than the signed version (for example an `unsigned int` is stored in a `long`). Serialisation proceeded originally according to the implementation size, then tweaks became necessary to match the expectations of other software. This produced quite a complex situation internally and external behaviour that remained surprising (#119).

After this change, `array.array` internal representations have changed so that the unsigned types use the same representation as the corresponding signed type, and `itemsize` will be consistent with serialisation.
