### PR TITLE
Implement Comparison enum and abstract API

### DIFF
--- a/build-tools/python/lib/core/PyLong.py
+++ b/build-tools/python/lib/core/PyLong.py
@@ -1,4 +1,4 @@
-# PyLong.py: A generator for Java files that define the Python float
+# PyLong.py: A generator for Java files that define the Python int
 
 # Copyright (c)2021 Jython Developers.
 # Licensed to PSF under a contributor agreement.

--- a/core/src/main/java/org/python/core/Comparison.java
+++ b/core/src/main/java/org/python/core/Comparison.java
@@ -1,0 +1,270 @@
+// Copyright (c)2021 Jython Developers.
+// Licensed to PSF under a contributor agreement.
+package org.python.core;
+
+import java.lang.invoke.MethodHandle;
+
+import org.python.core.Slot.EmptyException;
+
+/**
+ * Selects a particular "rich comparison" operation from the
+ * repertoire supported by {@link Opcode#COMPARE_OP}, the argument
+ * to which is the {@code code} attribute of the name in this
+ * {@code enum}.
+ *
+ * @apiNote The order matches CPython's enumeration of operations
+ *     used in the argument to {@code COMPARE_OP}, so that we can
+ *     rely on it in the CPython byte code interpreter.
+ */
+enum Comparison {
+    // Order and number must be reflected in swap[].
+
+    /** The {@code __lt__} operation. */
+    LT("<", Slot.op_lt) {
+
+        @Override
+        boolean toBool(int c) { return c < 0; }
+    },
+
+    /** The {@code __le__} operation. */
+    LE("<=", Slot.op_le) {
+
+        @Override
+        boolean toBool(int c) { return c <= 0; }
+    },
+
+    /** The {@code __eq__} operation. */
+    EQ("==", Slot.op_eq) {
+
+        @Override
+        boolean toBool(int c) { return c == 0; }
+    },
+
+    /** The {@code __ne__} operation. */
+    NE("!=", Slot.op_ne) {
+
+        @Override
+        boolean toBool(int c) { return c != 0; }
+    },
+
+    /** The {@code __gt__} operation. */
+    GT(">", Slot.op_gt) {
+
+        @Override
+        boolean toBool(int c) { return c > 0; }
+    },
+
+    /** The {@code __ge__} operation. */
+    GE(">=", Slot.op_ge) {
+
+        @Override
+        boolean toBool(int c) { return c >= 0; }
+    },
+
+    /** The (reflected) {@code __contains__} operation. */
+    IN("in", Slot.op_contains) {
+
+        @Override
+        boolean toBool(int c) { return c >= 0; }
+
+        @Override
+        Object apply(Object v, Object w) throws Throwable {
+            Operations vOps = Operations.of(v);
+            try {
+                MethodHandle contains = slot.getSlot(vOps);
+                return (boolean)contains.invokeExact(w, v);
+            } catch (Slot.EmptyException e) {
+                throw new TypeError(NOT_CONTAINER, vOps.type(v).name);
+            }
+        }
+    },
+
+    /** The inverted (reflected) {@code __contains__} operation. */
+    NOT_IN("not in", Slot.op_contains) {
+
+        @Override
+        boolean toBool(int c) { return c < 0; }
+
+        @Override
+        Object apply(Object v, Object w) throws Throwable {
+            Operations vOps = Operations.of(v);
+            ;
+            try {
+                MethodHandle contains = slot.getSlot(vOps);
+                return (boolean)contains.invokeExact(w, v);
+            } catch (Slot.EmptyException e) {
+                throw new TypeError(NOT_CONTAINER, vOps.type(v).name);
+            }
+        }
+    },
+
+    /** The identity operation. */
+    IS("is") {
+
+        @Override
+        boolean toBool(int c) { return c == 0; }
+
+        @Override
+        Object apply(Object v, Object w) throws Throwable { return v == w; }
+
+    },
+
+    /** The inverted identity operation. */
+    IS_NOT("is not") {
+
+        @Override
+        boolean toBool(int c) { return c != 0; }
+
+        @Override
+        Object apply(Object v, Object w) throws Throwable { return v != w; }
+    },
+
+    /** The exception matching operation. */
+    EXC_MATCH("matches") {
+
+        @Override
+        boolean toBool(int c) { return c == 0; }
+
+        @Override
+        Object apply(Object v, Object w) throws Throwable {
+            return Py.NotImplemented; // XXX implement me!
+        }
+    },
+
+    /** A dummy operation representing an invalid comparison. */
+    BAD("?") {
+
+        @Override
+        boolean toBool(int c) { return false; }
+
+        @Override
+        Object apply(Object v, Object w) throws Throwable { return Py.NotImplemented; }
+    };
+
+    final String text;
+    final Slot slot;
+
+    Comparison(String text, Slot slot) {
+        this.text = text;
+        this.slot = slot;
+    }
+
+    Comparison(String text) { this(text, null); }
+
+    /**
+     * The text corresponding to the value, e.g. "!=" for {@code NE},
+     * "is not" for {@code IS_NOT}. Mostly for error messages.
+     *
+     * @return text corresponding
+     */
+    @Override
+    public String toString() { return text; }
+
+    /**
+     * Translate CPython {@link Opcode#COMPARE_OP} opcode argument to
+     * Comparison constant.
+     *
+     * @param oparg opcode argument
+     * @return equivalent {@code Comparison} object
+     */
+    static Comparison from(int oparg) {
+        return oparg >= 0 && oparg < from.length ? from[oparg] : BAD;
+    }
+
+    private static final Comparison[] from = values();
+
+    /**
+     * The swapped version of this comparison, e.g. LT with GT.
+     *
+     * @return swapped version of this comparison
+     */
+    Comparison swapped() { return swap[this.ordinal()]; }
+
+    private static final Comparison[] swap =
+            {GT, GE, EQ, NE, LT, LE, BAD, BAD, IS, IS_NOT, BAD, BAD};
+
+    /**
+     * Translate a comparison result into the appropriate boolean, for
+     * example {@code GE.toBool(1)} is {@link Py#True}. For the the six
+     * operations LT to GE inclusive, this is typically wrapped onto a
+     * call to {@code Comparable.compareTo()}). For the others we assume
+     * c==0 indicates equality.
+     * <p>
+     * Avoid the temptation to use the result of a subtraction here
+     * unless there is no possibility of overflow in the subtraction.
+     *
+     * @param c comparison result
+     * @return boolean equivalent for this operation
+     */
+    // Compare CPython object.h::Py_RETURN_RICHCOMPARE
+    abstract boolean toBool(int c);
+
+    /**
+     * Perform this comparison, raising {@code TypeError} when the
+     * requested comparison operator is not supported.
+     *
+     * @param v left operand
+     * @param w right operand
+     * @return comparison result
+     * @throws Throwable from the implementation of the comparison
+     */
+    // Compare CPython PyObject_RichCompare, do_richcompare in object.c
+    Object apply(Object v, Object w) throws Throwable {
+        Operations vOps = Operations.of(v);
+        PyType vType = vOps.type(v);
+        Operations wOps = Operations.of(w);
+        PyType wType = wOps.type(w);
+        Slot swappedSlot = null;
+
+        // Try the swapped operation first if w is a sub-type of v
+
+        if (vType != wType && wType.isSubTypeOf(vType)) {
+            swappedSlot = swapped().slot;
+            try {
+                Object r = swappedSlot.getSlot(wOps).invokeExact(w, v);
+                if (r != Py.NotImplemented) { return r; }
+            } catch (EmptyException e) {}
+        }
+
+        // Try the forward operation
+        try {
+            Object r = slot.getSlot(vOps).invokeExact(v, w);
+            if (r != Py.NotImplemented) { return r; }
+        } catch (EmptyException e) {}
+
+        // Try the swapped operation if we haven't already
+        if (swappedSlot == null) {
+            swappedSlot = swapped().slot;
+            try {
+                Object r = swappedSlot.getSlot(wOps).invokeExact(w, v);
+                if (r != Py.NotImplemented) { return r; }
+            } catch (EmptyException e) {}
+        }
+
+        // Neither object implements this. Base == and != on identity.
+        switch (this) {
+            case EQ:
+                return v == w;
+            case NE:
+                return v != w;
+            default:
+                throw comparisonTypeError(v, w);
+        }
+    }
+
+    /**
+     * Create a TypeError along the lines "OP not supported between
+     * instances of V and W"
+     *
+     * @param v left arg
+     * @param w right arg
+     * @return the exception
+     */
+    PyException comparisonTypeError(Object v, Object w) {
+        return new TypeError(NOT_SUPPORTED, this, PyType.of(v).name, PyType.of(w).name);
+    }
+
+    private static String NOT_SUPPORTED =
+            "'%s' not supported between instances of '%.100s' and '%.100s'";
+    private static String NOT_CONTAINER = "'%.200s' object is not a container";
+}

--- a/core/src/test/java/org/python/core/AbstractAPITest.java
+++ b/core/src/test/java/org/python/core/AbstractAPITest.java
@@ -3,10 +3,13 @@
 package org.python.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
+import java.util.Iterator;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +42,10 @@ class AbstractAPITest extends UnitTestSupport {
         abstract void supports_str() throws Throwable;
 
         abstract void supports_hash() throws Throwable;
+
+        abstract void supports_isTrue() throws Throwable;
+
+        abstract void supports_richCompare() throws Throwable;
 
         abstract void supports_getAttr_String() throws Throwable;
 
@@ -79,6 +86,34 @@ class AbstractAPITest extends UnitTestSupport {
         @Test
         void supports_hash() throws Throwable {
             for (Object v : all) { assertEquals(v.hashCode(), Abstract.hash(v)); }
+        }
+
+        @Override
+        @Test
+        void supports_isTrue() throws Throwable {
+            // Zero is false
+            assertFalse(Abstract.isTrue(zero));
+            // The rest are true
+            Iterator<Object> rest = all.listIterator(1);
+            while (rest.hasNext()) { assertTrue(Abstract.isTrue(rest.next())); }
+        }
+
+        @Override
+        @Test
+        void supports_richCompare() throws Throwable {
+            // Let's not try to be exhaustive
+            assertEquals(Boolean.TRUE, Abstract.richCompare(zero, small, Comparison.LT));
+            assertEquals(Boolean.TRUE, Abstract.richCompare(large, large, Comparison.LE));
+            assertEquals(Boolean.TRUE, Abstract.richCompare(zero, negative, Comparison.GT));
+            assertEquals(Boolean.TRUE, Abstract.richCompare(large, large, Comparison.GE));
+            assertEquals(Boolean.TRUE, Abstract.richCompare(zero, "zero", Comparison.NE));
+            assertEquals(Boolean.TRUE, Abstract.richCompare(zero, 0, Comparison.EQ));
+            assertEquals(Boolean.FALSE, Abstract.richCompare(small, negative, Comparison.LT));
+            assertEquals(Boolean.FALSE, Abstract.richCompare(small, small, Comparison.GT));
+            assertEquals(Boolean.FALSE, Abstract.richCompare(large, small, Comparison.LE));
+            assertEquals(Boolean.FALSE, Abstract.richCompare(large, large, Comparison.NE));
+            assertEquals(Boolean.FALSE, Abstract.richCompare(zero, small, Comparison.GE));
+            assertEquals(Boolean.FALSE, Abstract.richCompare(zero, "zero", Comparison.EQ));
         }
 
         @Override

--- a/core/src/test/java/org/python/core/ComparisonSlotWrapperTest.java
+++ b/core/src/test/java/org/python/core/ComparisonSlotWrapperTest.java
@@ -1,0 +1,177 @@
+// Copyright (c)2021 Jython Developers.
+// Licensed to PSF under a contributor agreement.
+package org.python.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test the {@link PyWrapperDescr}s for comparison special functions
+ * on a variety of types.
+ */
+class ComparisonSlotWrapperTest extends UnitTestSupport {
+
+    /**
+     * Test invocation of the {@code float.__lt__} descriptor on
+     * accepted {@code float} classes in all combinations with
+     * {@code float} and {@code int} operand types.
+     */
+    @Test
+    void float_lt() throws Throwable {
+
+        PyWrapperDescr lt = (PyWrapperDescr)PyFloat.TYPE.lookup("__lt__");
+
+        Double dv = 7.0, dw = 6.0;
+        PyFloat pv = newPyFloat(dv), pw = newPyFloat(dw);
+        Integer iw = 6;
+
+        List<Object> wList =
+                List.of(pw, dw, newPyLong(iw), iw, BigInteger.valueOf(iw), false, true);
+
+        // v is Double, PyFloat.
+        for (Object v : List.of(dv, pv)) {
+            // w is PyFloat, Double, and int types
+            for (Object w : wList) {
+                Object r = lt.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(false, r);
+            }
+        }
+
+        dv = -0.1;  // less than everything in wList
+        pv = newPyFloat(dv);
+
+        // v is Double, PyFloat.
+        for (Object v : List.of(dv, pv)) {
+            // w is PyFloat, Double, and int types
+            for (Object w : wList) {
+                Object r = lt.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(true, r);
+            }
+        }
+    }
+
+    /**
+     * Test invocation of the {@code float.__eq__} descriptor on
+     * accepted {@code float} classes in all combinations with
+     * {@code float} and {@code int} operand types.
+     */
+    @Test
+    void float_eq() throws Throwable {
+
+        PyWrapperDescr eq = (PyWrapperDescr)PyFloat.TYPE.lookup("__eq__");
+
+        Double dv = 2.0, dw = 1.0;
+        PyFloat pv = newPyFloat(dv), pw = newPyFloat(dw);
+        Integer iw = 1;
+
+        List<Object> wList = List.of(pw, dw, newPyLong(iw), iw, BigInteger.valueOf(iw), true);
+
+        // v is Double, PyFloat.
+        for (Object v : List.of(dv, pv)) {
+            // w is PyFloat, Double, and int types
+            for (Object w : wList) {
+                Object r = eq.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(false, r);
+            }
+        }
+
+        dv = dw;  // equal to everything in wList
+        pv = newPyFloat(dv);
+
+        // v is Double, PyFloat.
+        for (Object v : List.of(dv, pv)) {
+            // w is PyFloat, Double, and int types
+            for (Object w : wList) {
+                Object r = eq.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(true, r);
+            }
+        }
+    }
+
+    /**
+     * Test invocation of the {@code int.__lt__} descriptor on accepted
+     * {@code int} classes in all combinations.
+     */
+    @Test
+    void int_lt() throws Throwable {
+
+        PyWrapperDescr lt = (PyWrapperDescr)PyLong.TYPE.lookup("__lt__");
+
+        Integer iv = 4, iw = -1;
+        BigInteger bv = BigInteger.valueOf(iv), bw = BigInteger.valueOf(iw);
+        PyLong pv = newPyLong(iv), pw = newPyLong(iw);
+
+        // v is Integer, BigInteger, PyLong, Boolean
+        for (Object v : List.of(iv, bv, pv, true)) {
+            // w is Integer, BigInteger, PyLong, Boolean
+            for (Object w : List.of(iw, bw, pw, false)) {
+                Object r = lt.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(false, r);
+            }
+        }
+
+        bv = BigInteger.valueOf(iv = -2);
+        pv = newPyLong(iv);
+        bw = BigInteger.valueOf(iw = 3);
+        pw = newPyLong(iw);
+
+        // v is Integer, BigInteger, PyLong, Boolean
+        for (Object v : List.of(iv, bv, pv, false)) {
+            // w is Integer, BigInteger, PyLong, Boolean
+            for (Object w : List.of(iw, bw, pw, true)) {
+                Object r = lt.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(true, r);
+            }
+        }
+    }
+
+    /**
+     * Test invocation of the {@code int.__eq__} descriptor on accepted
+     * {@code int} classes in all combinations.
+     */
+    @Test
+    void int_eq() throws Throwable {
+
+        PyWrapperDescr eq = (PyWrapperDescr)PyLong.TYPE.lookup("__eq__");
+
+        Integer iv = 5, iw = 7;
+        BigInteger bv = BigInteger.valueOf(iv), bw = BigInteger.valueOf(iw);
+        PyLong pv = newPyLong(iv), pw = newPyLong(iw);
+
+        // v is Integer, BigInteger, PyLong, Boolean
+        for (Object v : List.of(iv, bv, pv, true)) {
+            // w is Integer, BigInteger, PyLong, Boolean
+            for (Object w : List.of(iw, bw, pw, false)) {
+                Object r = eq.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(false, r);
+            }
+        }
+
+        iv = iw = 1;
+        bv = BigInteger.valueOf(iv);
+        pv = newPyLong(iv);
+        bw = BigInteger.valueOf(iw);
+        pw = newPyLong(iw);
+
+        // v is Integer, BigInteger, PyLong, Boolean
+        for (Object v : List.of(iv, bv, pv, true)) {
+            // w is Integer, BigInteger, PyLong, Boolean
+            for (Object w : List.of(iw, bw, pw, true)) {
+                Object r = eq.__call__(new Object[] {v, w}, null);
+                assertEquals(Boolean.class, r.getClass());
+                assertEquals(true, r);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We add tests and a neat `enum` that expresses the types of comparison we have to support, together with the logic (very similar to that of binary operations) by which e.g. `__lt__` delegates to `__gt__` on the right-hand argument.

The "rich comparison" support in Abstract is quite faithful to the reference implementation (CPython).

The code that actually makes comparisons was already generated in the implementations.