### PR TITLE
fix: safely compare strings using `.equals` instead of `==`

### DIFF
--- a/src/org/python/core/PyClass.java
+++ b/src/org/python/core/PyClass.java
@@ -106,62 +106,68 @@ public class PyClass extends PyObject implements Traverseproc {
 
     @Override
     public PyObject __findattr_ex__(String name) {
-        if (name == "__dict__") {
-            return __dict__;
+        if (name == null) {
+            return null;
         }
-        if (name == "__bases__") {
-            return __bases__;
+        switch (name) {
+            case "__dict__":
+                return __dict__;
+            case "__bases__":
+                return __bases__;
+            case "__name__":
+                return Py.newString(__name__);
+            default:
+                PyObject result = lookup(name);
+                if (result == null) {
+                    return result;
+                }
+                return result.__get__(null, this);
         }
-        if (name == "__name__") {
-            return Py.newString(__name__);
-        }
-
-        PyObject result = lookup(name);
-        if (result == null) {
-            return result;
-        }
-        return result.__get__(null, this);
     }
 
     @Override
     public void __setattr__(String name, PyObject value) {
-        if (name == "__dict__") {
-            setDict(value);
-            return;
-        } else if (name == "__bases__") {
-            setBases(value);
-            return;
-        } else if (name == "__name__") {
-            setName(value);
-            return;
-        } else if (name == "__getattr__") {
-            __getattr__ = value;
-            return;
-        } else if (name == "__setattr__") {
-            __setattr__ = value;
-            return;
-        } else if (name == "__delattr__") {
-            __delattr__ = value;
-            return;
-        } else if (name == "__tojava__") {
-            __tojava__ = value;
-            return;
-        } else if (name == "__del__") {
-            __del__ = value;
-            return;
-        } else if (name == "__contains__") {
-            __contains__ = value;
+        if (name == null) {
             return;
         }
-
-        if (value == null) {
-            try {
-                __dict__.__delitem__(name);
-            } catch (PyException pye) {
-                noAttributeError(name);
-            }
+        switch (name) {
+            case "__dict__":
+                setDict(value);
+                return;
+            case "__bases__":
+                setBases(value);
+                return;
+            case "__name__":
+                setName(value);
+                return;
+            case "__getattr__":
+                __getattr__ = value;
+                return;
+            case "__setattr__":
+                __setattr__ = value;
+                return;
+            case "__delattr__":
+                __delattr__ = value;
+                return;
+            case "__tojava__":
+                __tojava__ = value;
+                return;
+            case "__del__":
+                __del__ = value;
+                return;
+            case "__contains__":
+                __contains__ = value;
+                return;
+            default:
+                if (value == null) {
+                    try {
+                        __dict__.__delitem__(name);
+                    } catch (PyException pye) {
+                        noAttributeError(name);
+                    }
+                }
+                __dict__.__setitem__(name, value);
         }
-        __dict__.__setitem__(name, value);
     }
 
     @Override
@@ -206,7 +212,7 @@ public class PyClass extends PyObject implements Traverseproc {
             return -2;
         }
         int c = __name__.compareTo(((PyClass) other).__name__);
-        return c < 0 ? -1 : c > 0 ? 1 : 0;
+        return Integer.compare(c, 0);
     }
 
     @Override
@@ -218,7 +224,7 @@ public class PyClass extends PyObject implements Traverseproc {
             return new PyString(__name__);
         }
         PyObject mod = __dict__.__finditem__("__module__");
-        if (mod == null || !(mod instanceof PyString)) {
+        if (!(mod instanceof PyString)) {
             return new PyString(__name__);
         }
         String smod = ((PyString) mod).toString();
@@ -248,14 +254,14 @@ public class PyClass extends PyObject implements Traverseproc {
     }
 
     public void setDict(PyObject value) {
-        if (value == null || !(value instanceof AbstractDict)) {
+        if (!(value instanceof AbstractDict)) {
             throw Py.TypeError("__dict__ must be a dictionary object");
         }
         __dict__ = value;
     }
 
     public void setBases(PyObject value) {
-        if (value == null || !(value instanceof PyTuple)) {
+        if (!(value instanceof PyTuple)) {
             throw Py.TypeError("__bases__ must be a tuple object");
         }
 
@@ -320,7 +326,7 @@ public class PyClass extends PyObject implements Traverseproc {
                 return retVal;
             }
         }
-        
+
         /* Jython-only */
         if (__tojava__ != null) {
             retVal = visit.visit(__tojava__, arg);

--- a/src/org/python/core/PyJavaPackage.java
+++ b/src/org/python/core/PyJavaPackage.java
@@ -66,7 +66,7 @@ public class PyJavaPackage extends PyObject implements Traverseproc {
         String remainder = null;
         if (dot != -1) {
             firstName = name.substring(0, dot);
-            remainder = name.substring(dot + 1, name.length());
+            remainder = name.substring(dot + 1);
         }
         firstName = firstName.intern();
         PyJavaPackage p = (PyJavaPackage) __dict__.__finditem__(firstName);
@@ -123,6 +123,9 @@ public class PyJavaPackage extends PyObject implements Traverseproc {
 
     @Override
     public PyObject __findattr_ex__(String name) {
+        if (name == null) {
+            return null;
+        }
 
         PyObject ret = __dict__.__finditem__(name);
 
@@ -137,30 +140,32 @@ public class PyJavaPackage extends PyObject implements Traverseproc {
             Class<?> c = __mgr__.findClass(__name__, name);
             if (c != null) {
                 return addClass(name, c);
-            } else if (name == "__name__") {
-                return new PyString(__name__);
-            } else if (name == "__dict__") {
-                return __dict__;
-            } else if (name == "__mgr__") {
-                return Py.java2py(__mgr__);
-            } else if (name == "__file__") {
-                // Stored as UTF-16 for Java but expected as bytes in Python
-                return __file__ == null ? Py.None : Py.fileSystemEncode(__file__);
-            } else {
-                return null;
+            }
+            switch (name) {
+                case "__name__":
+                    return new PyString(__name__);
+                case "__dict__":
+                    return __dict__;
+                case "__mgr__":
+                    return Py.java2py(__mgr__);
+                case "__file__":
+                    // Stored as UTF-16 for Java but expected as bytes in Python
+                    return __file__ == null ? Py.None : Py.fileSystemEncode(__file__);
+                default:
+                    return null;
             }
         }
     }
 
     @Override
     public void __setattr__(String attr, PyObject value) {
-        if (attr == "__mgr__") {
+        if ("__mgr__".equals(attr)) {
             PackageManager newMgr = Py.tojava(value, PackageManager.class);
             if (newMgr == null) {
                 throw Py.TypeError("cannot set java package __mgr__ to None");
             }
             __mgr__ = newMgr;
-        } else if (attr == "__file__") {
+        } else if ("__file__".equals(attr)) {
             // Stored as UTF-16 for Java but presented as bytes from Python
             __file__ = Py.fileSystemDecode(value);
         } else {

--- a/src/org/python/core/PyModule.java
+++ b/src/org/python/core/PyModule.java
@@ -219,7 +219,7 @@ public class PyModule extends PyObject implements Traverseproc {
 
     @ExposedMethod
     final void module___setattr__(String name, PyObject value) {
-        if (name != "__dict__") {
+        if (!"__dict__".equals(name)) {
             ensureDict();
         }
         super.__setattr__(name, value);

--- a/src/org/python/core/PyObject.java
+++ b/src/org/python/core/PyObject.java
@@ -1971,7 +1971,7 @@ public class PyObject implements Serializable {
         // situations
         // XXX: This method isn't expensive but could (and maybe
         // should?) be optimized for worst case scenarios
-        return (op == "+") && (t1 == PyString.TYPE || t1 == PyUnicode.TYPE)
+        return ("+".equals(op)) && (t1 == PyString.TYPE || t1 == PyUnicode.TYPE)
                 && (t2.isSubType(PyString.TYPE) || t2.isSubType(PyUnicode.TYPE));
     }
 

--- a/src/org/python/core/PySuper.java
+++ b/src/org/python/core/PySuper.java
@@ -87,7 +87,7 @@ public class PySuper extends PyObject implements Traverseproc {
         } else {
             // Try the slow way
             PyObject classAttr = obj.__findattr__("__class__");
-            if (classAttr != null && classAttr instanceof PyType) {
+            if (classAttr instanceof PyType) {
                 if (((PyType)classAttr).isSubType(type)) {
                     return (PyType)classAttr;
                 }
@@ -101,7 +101,7 @@ public class PySuper extends PyObject implements Traverseproc {
     }
 
     final PyObject super___findattr_ex__(String name) {
-        if (objType != null && name != "__class__") {
+        if (objType != null && !"__class__".equals(name)) {
             PyObject descr = objType.super_lookup(superType, name);
             if (descr != null) {
                 return descr.__get__(objType == obj ? null : obj, objType);

--- a/src/org/python/core/PyTableCode.java
+++ b/src/org/python/core/PyTableCode.java
@@ -13,7 +13,7 @@ public class PyTableCode extends PyBaseCode
     int func_id;
     public String co_code = ""; // only used by inspect
 
-    public PyTableCode(int argcount, String varnames[],
+    public PyTableCode(int argcount, String[] varnames,
                        String filename, String name,
                        int firstlineno,
                        boolean varargs, boolean varkwargs,
@@ -23,7 +23,7 @@ public class PyTableCode extends PyBaseCode
              varkwargs, funcs, func_id, null, null, 0, 0);
     }
 
-    public PyTableCode(int argcount, String varnames[],
+    public PyTableCode(int argcount, String[] varnames,
                        String filename, String name,
                        int firstlineno,
                        boolean varargs, boolean varkwargs,
@@ -65,7 +65,7 @@ public class PyTableCode extends PyBaseCode
 
     @Override
     public PyObject __dir__() {
-        PyString members[] = new PyString[__members__.length];
+        PyString[] members = new PyString[__members__.length];
         for (int i = 0; i < __members__.length; i++) {
             members[i] = new PyString(__members__[i]);
         }
@@ -73,8 +73,8 @@ public class PyTableCode extends PyBaseCode
     }
 
     private void throwReadonly(String name) {
-        for (int i = 0; i < __members__.length; i++) {
-            if (__members__[i] == name) {
+        for (String s : __members__) {
+            if (s.equals(name)) {
                 throw Py.TypeError("readonly attribute");
             }
         }
@@ -106,24 +106,23 @@ public class PyTableCode extends PyBaseCode
 
     @Override
     public PyObject __findattr_ex__(String name) {
+        if (name == null) {
+            return null;
+        }
         // have to craft co_varnames specially
-        if (name == "co_varnames") {
-            return toPyStringTuple(co_varnames);
-        }
-        if (name == "co_cellvars") {
-            return toPyStringTuple(co_cellvars);
-        }
-        if (name == "co_freevars") {
-            return toPyStringTuple(co_freevars);
-        }
-        if (name == "co_filename") {
-            return Py.fileSystemEncode(co_filename); // bytes object expected by clients
-        }
-        if (name == "co_name") {
-            return new PyString(co_name);
-        }
-        if (name == "co_flags") {
-            return Py.newInteger(co_flags.toBits());
+        switch (name) {
+            case "co_varnames":
+                return toPyStringTuple(co_varnames);
+            case "co_cellvars":
+                return toPyStringTuple(co_cellvars);
+            case "co_freevars":
+                return toPyStringTuple(co_freevars);
+            case "co_filename":
+                return Py.fileSystemEncode(co_filename); // bytes object expected by clients
+            case "co_name":
+                return new PyString(co_name);
+            case "co_flags":
+                return Py.newInteger(co_flags.toBits());
         }
         return super.__findattr_ex__(name);
     }

--- a/src/org/python/modules/_marshal.java
+++ b/src/org/python/modules/_marshal.java
@@ -511,7 +511,7 @@ public class _marshal implements ClassDictInit {
                 case TYPE_SET:
                 case TYPE_FROZENSET: {
                     int n = read_int();
-                    PyObject items[] = new PyObject[n];
+                    PyObject[] items = new PyObject[n];
                     for (int i = 0; i < n; i++) {
                         items[i] = read_object(depth + 1);
                     }
@@ -531,11 +531,11 @@ public class _marshal implements ClassDictInit {
                     int stacksize = read_int();
                     int flags = read_int();
                     String code = read_object_notnull(depth + 1).toString();
-                    PyObject consts[] = ((PyTuple) read_object_notnull(depth + 1)).getArray();
-                    String names[] = read_strings(depth + 1);
-                    String varnames[] = read_strings(depth + 1);
-                    String freevars[] = read_strings(depth + 1);
-                    String cellvars[] = read_strings(depth + 1);
+                    PyObject[] consts = ((PyTuple) read_object_notnull(depth + 1)).getArray();
+                    String[] names = read_strings(depth + 1);
+                    String[] varnames = read_strings(depth + 1);
+                    String[] freevars = read_strings(depth + 1);
+                    String[] cellvars = read_strings(depth + 1);
                     String filename = read_object_notnull(depth + 1).toString();
                     String name = read_object_notnull(depth + 1).toString();
                     int firstlineno = read_int();

--- a/src/org/python/modules/cStringIO.java
+++ b/src/org/python/modules/cStringIO.java
@@ -136,7 +136,7 @@ public class cStringIO {
 
         @Override
         public void __setattr__(String name, PyObject value) {
-            if (name == "softspace") {
+            if ("softspace".equals(name)) {
                 softspace = value.__nonzero__();
                 return;
             }

--- a/src/org/python/modules/posix/PosixModule.java
+++ b/src/org/python/modules/posix/PosixModule.java
@@ -27,6 +27,7 @@ import java.nio.file.attribute.FileTime;
 import java.security.SecureRandom;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import jnr.constants.Constant;
@@ -933,7 +934,7 @@ public class PosixModule implements ClassDictInit {
         if (errno == Errno.__UNKNOWN_CONSTANT__) {
             return new PyString("Unknown error: " + code);
         }
-        if (errno.name() == errno.toString()) {
+        if (Objects.equals(errno.name(), errno.toString())) {
             // Fake constant or just lacks a description, fallback to Linux's
             // XXX: have jnr-constants handle this fallback
             errno = Enum.valueOf(jnr.constants.platform.linux.Errno.class,

--- a/src/org/python/modules/sre/MatchObject.java
+++ b/src/org/python/modules/sre/MatchObject.java
@@ -186,28 +186,33 @@ public class MatchObject extends PyObject implements Traverseproc {
     }
 
     public PyObject __findattr_ex__(String key) {
+        if (key == null) {
+            return null;
+        }
         //System.out.println("__findattr__:" + key);
-        if (key == "flags")
-            return Py.newInteger(pattern.flags);
-        if (key == "groupindex")
-            return pattern.groupindex;
-        if (key == "re")
-            return pattern;
-        if (key == "pos")
-            return Py.newInteger(pos);
-        if (key == "endpos")
-            return Py.newInteger(endpos);
-        if (key == "lastindex")
-            return lastindex == -1 ? Py.None : Py.newInteger(lastindex);
-        if (key == "lastgroup"){
-            if(pattern.indexgroup != null && lastindex >= 0)
-                return pattern.indexgroup.__getitem__(lastindex);
-            return Py.None;
+        switch (key) {
+            case "flags":
+                return Py.newInteger(pattern.flags);
+            case "groupindex":
+                return pattern.groupindex;
+            case "re":
+                return pattern;
+            case "pos":
+                return Py.newInteger(pos);
+            case "endpos":
+                return Py.newInteger(endpos);
+            case "lastindex":
+                return lastindex == -1 ? Py.None : Py.newInteger(lastindex);
+            case "lastgroup":
+                if (pattern.indexgroup != null && lastindex >= 0) {
+                    return pattern.indexgroup.__getitem__(lastindex);
+                }
+                return Py.None;
+            case "regs":
+                return regs();
+            default:
+                return super.__findattr_ex__(key);
         }
-        if ( key == "regs" ){
-            return regs();
-        }
-        return super.__findattr_ex__(key);
     }
 
 

--- a/src/org/python/modules/zipimport/zipimporter.java
+++ b/src/org/python/modules/zipimport/zipimporter.java
@@ -52,7 +52,7 @@ public class zipimporter extends importer<PyObject> implements Traverseproc {
         "a zipfile. ZipImportError is raised if 'archivepath' doesn't point to\n" +
         "a valid Zip archive.");
 
-    private static Logger log = Logger.getLogger("org.python.import");
+    private static final Logger log = Logger.getLogger("org.python.import");
 
     /** Path to the Zip archive */
     public String archive;
@@ -134,7 +134,7 @@ public class zipimporter extends importer<PyObject> implements Traverseproc {
             throw zipimport.ZipImportError("not a Zip file: " + path);
         }
 
-        if (prefix != "" && !prefix.endsWith(File.separator)) {
+        if (!"".equals(prefix) && !prefix.endsWith(File.separator)) {
             prefix += File.separator;
         }
     }
@@ -539,7 +539,7 @@ public class zipimporter extends importer<PyObject> implements Traverseproc {
      * ZipBundle is a ZipFile and one of its InputStreams, bundled together so the ZipFile can be
      * closed when finished with its InputStream.
      */
-    private class ZipBundle extends Bundle {
+    private static class ZipBundle extends Bundle {
         ZipFile zipFile;
 
         public ZipBundle(ZipFile zipFile, InputStream inputStream) {


### PR DESCRIPTION
Correctly compare Java Strings using `.equals()`/`switch case` instead of `==` (object identity)