### PR TITLE
Clarification concerning CLA and zxJDBC

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: pip install codespell
-    - run: codespell --count --ignore-words-list="sur,statics"
-                  NEWS README.md README.txt LICENSE Misc/INDEX Misc/codespell/README
+    - run: codespell --count --ignore-words=Misc/codespell/words.ignore
+                  NEWS README.md README.txt LICENSE.txt Misc/INDEX Misc/codespell/README
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -113,7 +113,7 @@ JPython version 1.1.x
      publicly, prepare derivative works, distribute, and otherwise use the
      Software alone or in any derivative version, provided, however, that
      CNRI's License Agreement and CNRI's notice of copyright, i.e.,
-     "Copyright ©1996-1999 Corporation for National Research Initiatives;
+     "Copyright (c)1996-1999 Corporation for National Research Initiatives;
      All Rights Reserved" are both retained in the Software, alone or in any
      derivative version prepared by Licensee.
 
@@ -184,17 +184,19 @@ In October 2000 Barry helped move the software to SourceForge
 where it was renamed to Jython. Jython 2.0 and 2.1 were developed
 under the Jython specific license below.
 
-From the 2.2 release on, Jython contributors have signed
-Python Software Foundation contributor agreements and releases are
-covered under the Python Software Foundation license version 2.
+From the 2.2 release on, Jython contributors have licensed their
+contributions to the Python Software Foundation under a Contributor
+Agreement, so as to permit distribution under the Python Software Foundation
+license.
 
 The Python standard library developed for CPython is also used in Jython, and
 (like Jython itself) is provided under the Python Software Foundation
 license. See the file LICENSE_CPython.txt for details.
 
 The zxJDBC package was written by Brian Zimmer and originally licensed
-under the GNU Public License.  The package is now covered by the Jython
-Software License.
+under the GNU Public License. The package is now licensed to the Python
+Software Foundation under a Contributor Agreement, so as to permit
+distribution under the Python Software Foundation license.
 
 Elements of the supporting libraries (appearing renamed in some Jython JARs)
 are covered by the Apache Software License.  See the file LICENSE_Apache.txt

--- a/README.txt
+++ b/README.txt
@@ -16,14 +16,15 @@ of new features: https://www.youtube.com/watch?v=hLm3garVQFo
 This release was compiled on @os.name@ using @java.vendor@ Java
 version @java.version@ and requires a minimum of Java @jdk.target.version@ to run.
 
-See ACKNOWLEDGMENTS for details about Jython's copyright, license,
-contributors, and mailing lists; and NEWS for detailed release notes,
-including bugs fixed, backward breaking changes, and new features.
+See LICENSE.txt for details about Jython's copyright and license, and NEWS
+for detailed release notes, including bugs fixed, backward breaking changes,
+and new features.
 
 The developers extend their thanks to all who contributed to this release
 of Jython, through bug reports, patches, pull requests, documentation
-changes, email and conversation in any media. We are grateful to the PSF for
-continuing practical help and support of the project.
+changes, email and conversation in any media. See ACKNOWLEDGMENTS for a
+list of contributors. We are grateful to the PSF for continuing practical
+help and support of the project.
 
 Testing
 -------


### PR DESCRIPTION
We are able to make a clearer statement regarding the license terms under which we bundle zxJDBC, thanks to (re-)confirmation of CLA from the author.

I'm naturally reluctant to mess with the text of a licence, as IANAL, but it needs to be clearer, see #74.

The separate paragraph about zxJDBC looks duplicative. I think technically it is, but the mention of an original release under a GNU license is helpful. The PSF CLA requires the contributor to agree to a licence compatible with the way the PSF chooses to distribute Python implementations.

The phrase "licensed to the PSF under a contributor agreement" appears to be important language in the CLA, so I've used the same words here to describe what contributors have actually done.

The change also gives better directions in the `README.txt` to `LICENSE.txt` and `ACKNOWLEDGMENTS` files, as that was an element in #74.
