### PR TITLE
Adjust logging hierarchy for org.python for jython command only

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ For more details, three sources are available according to type:
 
 Jython 2.7.3a1
   Bugs fixed
+    - [ GH-183 ] Console messages do not reach root logger (bjo 2896)
     - [ GH-178 ] Update icu4j JAR to 71.1
     - [ GH-177 ] Update Ant to 1.10.12 (Gradle build) (CVE-2020-1945, 2021-36374)
     - [ GH-160 ] Improve context of "Cannot create PyString with non-byte value"

--- a/src/org/python/core/PrePy.java
+++ b/src/org/python/core/PrePy.java
@@ -51,7 +51,12 @@ public class PrePy {
     /** {@link Options#verbose} level providing detail in support of debugging or tracing. */
     public static final int DEBUG = 3;
 
-    static final Level[] LEVELS = {//
+    /**
+     * A mapping from the traditional "verbosity" found in {@link Options#verbose} to the JUL Level,
+     * offset such that verbosity {@link #ERROR} maps to element 1 which contains
+     * {@code Level.SEVERE}.
+     */
+    private static final Level[] LEVELS = {//
             Level.OFF,      //
             Level.SEVERE,   // Legacy: ERROR
             Level.WARNING,  // Legacy: WARNING


### PR DESCRIPTION
PR addressing the concerns extensively discussed in #183, but briefly, that not everyone wants us to divert logging from the Jython implementation to the console, instead of bubbling it up to the root.

The aim is to leave the behaviour of the `jython` command as it is, but limit application to that case, and provide ways to opt into "Java natural" logging even then.