### PR TITLE
Socket sendall for large buffers using `memoryview`

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1640,7 +1640,7 @@ class FileObjectClassTestCase(SocketConnectedTest):
 
     def testClosedAttr(self):
         self.assert_(not self.serv_file.closed)
-        
+
     def _testClosedAttr(self):
         self.assert_(not self.cli_file.closed)
 
@@ -1651,11 +1651,16 @@ class PrivateFileObjectTestCase(unittest.TestCase):
 
     E.g. urllib2 wraps an httplib.HTTPResponse object with _fileobject.
     """
+    def sendall(self, data):
+        # StringIO doesn't respect bytes nature of memoryview
+        if isinstance(data, memoryview):
+            data = data.tobytes()
+        self.socket_like.write(data)
 
     def setUp(self):
         self.socket_like = StringIO()
         self.socket_like.recv = self.socket_like.read
-        self.socket_like.sendall = self.socket_like.write
+        self.socket_like.sendall = self.sendall
 
     def testPrivateFileObject(self):
         fileobject = socket._fileobject(self.socket_like, 'rb')

--- a/Lib/test/test_socket_jy.py
+++ b/Lib/test/test_socket_jy.py
@@ -158,10 +158,12 @@ class SocketOptionsTest(unittest.TestCase):
 
 class TimedBasicTCPTest(SocketConnectedTest):
 
+    BIG_SIZE = test_support.SOCK_MAX_SIZE // 3 + 1
+
     def __init__(self, methodName='runTest'):
         SocketConnectedTest.__init__(self, methodName=methodName)
 
-    def testSendAll(self):
+    def receiveAll(self):
         # Testing sendall() with a max-size string over TCP
         msg = bytearray()
         t0 = time.clock()
@@ -173,12 +175,32 @@ class TimedBasicTCPTest(SocketConnectedTest):
         t = time.clock() - t0
         if test_support.verbose:
             print>>sys.stderr, "%d bytes in %5.3f sec ... " % (len(msg), t),
-        self.assertEqual(''.join(map(chr, set(msg))), 'x')
-        self.assertEqual(len(msg), test_support.SOCK_MAX_SIZE)
+        self.assertEqual(''.join(map(chr, sorted(set(msg)))), 'xyz')
+        self.assertEqual(len(msg), TimedBasicTCPTest.BIG_SIZE*3)
 
-    def _testSendAll(self):
-        big_chunk = 'x' * test_support.SOCK_MAX_SIZE
-        self.serv_conn.sendall(big_chunk)
+    def testSendAllBytes(self):
+        # Testing sendall() with a max-size string over TCP
+        self.receiveAll()
+
+    def _testSendAllBytes(self):
+        big = bytearray('xyz') * TimedBasicTCPTest.BIG_SIZE
+        self.serv_conn.sendall(big)
+
+    def testSendAllStr(self):
+        # Testing sendall() with a max-size string over TCP
+        self.receiveAll()
+
+    def _testSendAllStr(self):
+        big = 'xyz' * TimedBasicTCPTest.BIG_SIZE
+        self.serv_conn.sendall(big)
+
+    def testSendAllBuffer(self):
+        # Testing sendall() with a max-size string over TCP
+        self.receiveAll()
+
+    def _testSendAllBuffer(self):
+        big = buffer('xyz' * TimedBasicTCPTest.BIG_SIZE)
+        self.serv_conn.sendall(big)
 
 
 def test_main():

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -36,7 +36,7 @@ __all__ = ["Error", "TestFailed", "ResourceDenied", "import_module",
            "get_original_stdout", "unload", "unlink", "rmtree", "forget",
            "is_resource_enabled", "requires", "find_unused_port", "bind_port",
            "fcmp", "have_unicode", "is_jython", "is_jython_nt",
-           "TESTFN", "HOST", "FUZZ",
+           "TESTFN", "HOST", "SOCK_MAX_SIZE", "FUZZ",
            "SAVEDCWD", "temp_cwd", "findfile", "sortdict", "check_syntax_error",
            "open_urlresource", "check_warnings", "check_py3k_warnings",
            "CleanImport", "EnvironmentVarGuard", "captured_output",
@@ -328,6 +328,13 @@ def requires(resource, msg=None):
 
 HOST = 'localhost'
 HOSTv6 = "::1"
+
+# A constant likely larger than the underlying OS socket buffer size, to make
+# writes blocking.
+# The socket buffer sizes can usually be tuned system-wide (e.g. through sysctl
+# on Linux), or on a per-socket basis (SO_SNDBUF/SO_RCVBUF). See issue #18643
+# for a discussion of this number).
+SOCK_MAX_SIZE = 16 * 1024 * 1024 + 1
 
 def find_unused_port(family=socket.AF_INET, socktype=socket.SOCK_STREAM):
     """Returns an unused port that should be suitable for binding.  This is

--- a/src/org/python/core/PyMemoryView.java
+++ b/src/org/python/core/PyMemoryView.java
@@ -1,6 +1,8 @@
 // Copyright (c) 2013 Jython Developers
 package org.python.core;
 
+import java.nio.ByteBuffer;
+
 import org.python.core.buffer.BaseBuffer;
 import org.python.core.util.StringUtil;
 import org.python.expose.ExposedGet;
@@ -76,6 +78,16 @@ public class PyMemoryView extends PySequence implements BufferProtocol, Traverse
         }
         throw Py.TypeError(
                 "cannot make memory view because object does not have the buffer interface");
+    }
+
+    @Override
+    public Object __tojava__(Class<?> c) {
+        if (c == ByteBuffer.class) {
+            // Present the memoryview as a Java NIO buffer
+            checkNotReleased();
+            return backing.getNIOByteBuffer();
+        }
+        return super.__tojava__(c);
     }
 
     // @ExposedGet(doc = obj_doc) // Not exposed in Python 2.7


### PR DESCRIPTION
This provides a `_socket._realsocket.sendall` that continues to send() until all the data has all gone. This fixes #60 (bjo 2618).

The PR follows the solution proposed by both [Roland Walter](https://bugs.jython.org/issue2618) and Gunter Bach (#80), but scope the lifetime of the `memoryview` using `with`.and There is also a test. We apply the fix also to ChildSocket.

There are FIXMEs in this code that lament our inability to use `memoryview` through its buffer interface, which results in a lot of data copying. A further change set is intended to correct that.