### PR TITLE
Include zxJDBCMessages resource in slim JAR

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,7 @@ Jython 2.7.3a1
     - [ GH-4 ] Swap from Mercurial to Git as our SCM tool
     - [ GH-2 ] Transfer closed-fixed issues in NEWS from frozen-mirror
     - [ 2924 ] module-info.class in root of JAR causes problems (also GH-54?)
+    - [ 2918 ] slim jar: missing resource file for zxJDBC (also GH-187)
     - [ 2892 ] Migrate from hg.python.org to GitHub
 
   New Features

--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ processResources {
     from(file('src')) {
         include 'META-INF/**'
         include 'org/python/modules/ucnhash.dat'
+        include 'com/ziclix/python/sql/resource/zxJDBCMessages.properties'
     }
 }
 


### PR DESCRIPTION
Rectify simple omission. We add resources explicitly because the project layout in Jython 2 does not favour Gradle's configuration by convention.  I also scanned for other possibly missing files -- none spotted. 

Fixes [bjo 2918](https://bugs.jython.org/issue2918) and resolves #187.
