### PR TITLE
Support non-ascii as unicode in repr and formatting

### DIFF
--- a/Lib/test/test_str_jy.py
+++ b/Lib/test/test_str_jy.py
@@ -35,6 +35,23 @@ class StrConstructorTest(unittest.TestCase):
         self.assertRaises(UnicodeEncodeError, str, java.lang.String(u"caf\xe9 noir"))
         self.assertRaises(UnicodeEncodeError, str, java.lang.String(u"abc\u0111efgh"))
 
+    def test_unicode_acceptance(self):
+        # Issue GH-192: for characters >127 repr returns unicode
+        # Note that repr(java.lang.String) does not get quotes (and never did).
+        s = java.lang.String(u"cafe noir") 
+        self.assertEquals('cafe noir', repr(s))
+        self.assertEquals('[cafe noir, 0]', repr([s, 0]))
+        self.assertEquals('(cafe noir, 0)', repr((s, 0)))
+
+        t = java.lang.String(u"caf\xe9 noir") 
+        self.assertEquals(u'café noir', repr(t))
+        self.assertEquals(u'[café noir, 0]', repr([t, 0]))
+        self.assertEquals(u'(café noir, 0)', repr((t, 0)))
+
+        u = java.lang.String(u"Way \u51fa")
+        self.assertEquals(u'Way 出', repr(u))
+        self.assertEquals(u'[Way 出, 0]', repr([u, 0]))
+        self.assertEquals(u'(Way 出, 0)', repr((u, 0)))
 
 class StringSlicingTest(unittest.TestCase):
 

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ For more details, three sources are available according to type:
 
 Jython 2.7.3a1
   Bugs fixed
+    - [ GH-192 ] PyString with non-byte value in formatting of collections
     - [ GH-183 ] Console messages do not reach root logger (bjo 2896)
     - [ GH-178 ] Update icu4j JAR to 71.1
     - [ GH-177 ] Update Ant to 1.10.12 (Gradle build) (CVE-2020-1945, 2021-36374)

--- a/src/org/python/core/PyObject.java
+++ b/src/org/python/core/PyObject.java
@@ -228,7 +228,7 @@ public class PyObject implements Serializable {
      */
     @ExposedMethod(names = "__str__", doc = BuiltinDocs.object___str___doc)
     public PyString __repr__() {
-        return new PyString(toString());
+        return Py.newStringOrUnicode(toString());
     }
 
     @Override


### PR DESCRIPTION
In a somewhat draconian move, we use `Py.newStringOrUnicode` within `PyObject.__repr__` so that collections and discovered Java types, where `toString()` may return anything, do not cause a non-byte `PyString` error.

This is a response to #192 .