### PR TITLE
Non byte str optimisation

### DIFF
--- a/src/org/python/core/Py.java
+++ b/src/org/python/core/Py.java
@@ -28,8 +28,6 @@ import org.python.core.adapter.ClassicPyObjectAdapter;
 import org.python.core.adapter.ExtensiblePyObjectAdapter;
 import org.python.modules.posix.PosixModule;
 
-import com.google.common.base.CharMatcher;
-
 import jline.console.UserInterruptException;
 import jnr.constants.Constant;
 import jnr.constants.platform.Errno;
@@ -82,15 +80,15 @@ public final class Py extends PrePy {
     /** The Python boolean True **/
     public final static PyBoolean True = new PyBoolean(true);
     /** A zero-length Python byte string **/
-    public final static PyString EmptyString = new PyString("");
+    public final static PyString EmptyString = new PyString("", true);
     /** A zero-length Python Unicode string **/
     public final static PyUnicode EmptyUnicode = new PyUnicode("");
     /** A Python string containing '\n' **/
-    public final static PyString Newline = new PyString("\n");
+    public final static PyString Newline = new PyString("\n", true);
     /** A Python unicode string containing '\n' **/
     public final static PyUnicode UnicodeNewline = new PyUnicode("\n");
     /** A Python string containing ' ' **/
-    public final static PyString Space = new PyString(" ");
+    public final static PyString Space = new PyString(" ", true);
     /** A Python unicode string containing ' ' **/
     public final static PyUnicode UnicodeSpace = new PyUnicode(" ");
     /** Set if the type object is dynamically allocated */
@@ -639,8 +637,26 @@ public final class Py extends PrePy {
         return makeCharacter(c);
     }
 
+    /**
+     * Create a {@link PyString} from a Java {@code String}. Thethe character codes must all be all
+     * &lt; 256. (This is checked.)
+     *
+     * @param s character codes are all &lt; 256.
+     * @return a new {@code PyString}
+     */
     public static PyString newString(String s) {
-        return new PyString(s);
+        return s.length() == 0 ? Py.EmptyString : new PyString(s);
+    }
+
+    /**
+     * Create a {@link PyString} from a Java {@code String} where the caller guarantees that the
+     * character codes are all &lt; 256. (This is <b>not</b> checked.)
+     *
+     * @param s character codes are all &lt; 256.
+     * @return a new {@code PyString}
+     */
+    static PyString newBytes(String s) {
+        return s.length() == 0 ? Py.EmptyString : new PyString(s, true);
     }
 
     /**
@@ -667,19 +683,19 @@ public final class Py extends PrePy {
      *         <code>s</code>.
      */
     public static PyString newStringOrUnicode(PyObject precedent, String s) {
-        if (!(precedent instanceof PyUnicode) && CharMatcher.ascii().matchesAllOf(s)) {
-            return Py.newString(s);
+        if (!(precedent instanceof PyUnicode) && PyString.charsFitWidth(s, 7)) {
+            return Py.newBytes(s);
         } else {
             return Py.newUnicode(s);
         }
     }
 
     public static PyString newStringUTF8(String s) {
-        if (CharMatcher.ascii().matchesAllOf(s)) {
+        if (PyString.charsFitWidth(s, 7)) {
             // ascii of course is a subset of UTF-8
-            return Py.newString(s);
+            return Py.newBytes(s);
         } else {
-            return Py.newString(codecs.PyUnicode_EncodeUTF8(s, null));
+            return Py.newBytes(codecs.PyUnicode_EncodeUTF8(s, null));
         }
     }
 
@@ -697,7 +713,7 @@ public final class Py extends PrePy {
      */
     public static String fileSystemDecode(PyString filename) {
         String s = filename.getString();
-        if (filename instanceof PyUnicode || CharMatcher.ascii().matchesAllOf(s)) {
+        if (filename instanceof PyUnicode || PyString.charsFitWidth(s, 7)) {
             // Already encoded or usable as ASCII
             return s;
         } else {
@@ -741,13 +757,13 @@ public final class Py extends PrePy {
      * @return encoded bytes version of path
      */
     public static PyString fileSystemEncode(String filename) {
-        if (CharMatcher.ascii().matchesAllOf(filename)) {
+        if (PyString.charsFitWidth(filename, 7)) {
             // Just wrap it as US-ASCII is a subset of the file system encoding
-            return Py.newString(filename);
+            return Py.newBytes(filename);
         } else {
             // It's non just US-ASCII, so must encode properly
             assert "utf-8".equals(PySystemState.FILE_SYSTEM_ENCODING.toString());
-            return Py.newString(codecs.PyUnicode_EncodeUTF8(filename, null));
+            return Py.newBytes(codecs.PyUnicode_EncodeUTF8(filename, null));
         }
     }
 
@@ -2024,6 +2040,7 @@ public final class Py extends PrePy {
         }
     }
 
+    /** Table used by {@link #makeCharacter(char)} to intern single character strings. */
     private final static PyString[] letters = new PyString[256];
 
     static {
@@ -2037,7 +2054,7 @@ public final class Py extends PrePy {
     }
 
     public static final PyString makeCharacter(char c) {
-        if (c <= 255) {
+        if (c < 256) {
             return letters[c];
         } else {
             // This will throw IllegalArgumentException since non-byte value

--- a/src/org/python/core/Py.java
+++ b/src/org/python/core/Py.java
@@ -80,15 +80,15 @@ public final class Py extends PrePy {
     /** The Python boolean True **/
     public final static PyBoolean True = new PyBoolean(true);
     /** A zero-length Python byte string **/
-    public final static PyString EmptyString = new PyString("", true);
+    public final static PyString EmptyString = PyString.fromInterned("");
     /** A zero-length Python Unicode string **/
     public final static PyUnicode EmptyUnicode = new PyUnicode("");
     /** A Python string containing '\n' **/
-    public final static PyString Newline = new PyString("\n", true);
+    public final static PyString Newline = PyString.fromInterned("\n");
     /** A Python unicode string containing '\n' **/
     public final static PyUnicode UnicodeNewline = new PyUnicode("\n");
     /** A Python string containing ' ' **/
-    public final static PyString Space = new PyString(" ", true);
+    public final static PyString Space = PyString.fromInterned(" ");
     /** A Python unicode string containing ' ' **/
     public final static PyUnicode UnicodeSpace = new PyUnicode(" ");
     /** Set if the type object is dynamically allocated */
@@ -714,7 +714,7 @@ public final class Py extends PrePy {
     public static String fileSystemDecode(PyString filename) {
         String s = filename.getString();
         if (filename instanceof PyUnicode || PyString.charsFitWidth(s, 7)) {
-            // Already encoded or usable as ASCII
+            // Already decoded or bytes usable as ASCII
             return s;
         } else {
             // It's bytes, so must decode properly

--- a/src/org/python/core/PyJavaPackage.java
+++ b/src/org/python/core/PyJavaPackage.java
@@ -3,9 +3,9 @@
 
 package org.python.core;
 
-import org.python.core.packagecache.PackageManager;
-
 import java.util.Collection;
+
+import org.python.core.packagecache.PackageManager;
 
 /** A representation of java package. */
 public class PyJavaPackage extends PyObject implements Traverseproc {
@@ -41,7 +41,7 @@ public class PyJavaPackage extends PyObject implements Traverseproc {
         clsSet = new PyStringMap();
 
         __dict__ = new PyStringMap();
-        __dict__.__setitem__("__name__", new PyString(__name__));
+        __dict__.__setitem__("__name__", Py.newString(__name__));
     }
 
     public PyJavaPackage addPackage(String name) {

--- a/src/org/python/core/PyModule.java
+++ b/src/org/python/core/PyModule.java
@@ -14,7 +14,7 @@ import org.python.expose.ExposedType;
  */
 @ExposedType(name = "module")
 public class PyModule extends PyObject implements Traverseproc {
-    private final PyObject moduleDoc = new PyString( //FIXME: not used (and not static)
+    private final PyObject moduleDoc = Py.newBytes( //FIXME: not used (and not static)
         "module(name[, doc])\n" +
         "\n" +
         "Create a module object.\n" +
@@ -60,7 +60,7 @@ public class PyModule extends PyObject implements Traverseproc {
         ensureDict();
         __dict__.__setitem__("__name__", name);
         __dict__.__setitem__("__doc__", doc);
-        if (name.equals(new PyString("__main__"))) {
+        if (name.equals(Py.newBytes("__main__"))) {
             __dict__.__setitem__("__builtins__", Py.getSystemState().modules.__finditem__("__builtin__"));
             __dict__.__setitem__("__package__", Py.None);
         }
@@ -250,7 +250,7 @@ public class PyModule extends PyObject implements Traverseproc {
             filename = __dict__.__finditem__("__file__");
         }
         if (name == null) {
-            name = new PyString("?");
+            name = Py.newString('?');
         }
         if (filename == null) {
             return String.format("<module '%s' (built-in)>", name);

--- a/src/org/python/core/PyString.java
+++ b/src/org/python/core/PyString.java
@@ -134,12 +134,19 @@ public class PyString extends PyBaseString implements BufferProtocol {
         }
     }
 
+
     /**
-     * Creates a PyString from an already interned String. Just means it won't be reinterned if used
-     * in a place that requires interned Strings.
+     * Creates a {@code PyString} from an already interned {@code String} representing bytes. The
+     * caller guarantees that the character codes are all &lt; 256. (The method is used frequently
+     * from compiled code, and with identifiers, where this is guaranteed.) Just means it won't be
+     * re-interned if used in a place that requires interned Strings.
+     *
+     * @param interned {@code String} representing bytes
+     * @return {@code PyString} for those bytes
      */
     public static PyString fromInterned(String interned) {
-        PyString str = new PyString(TYPE, interned);
+        assert charsFitWidth(interned, 8);
+        PyString str = new PyString(TYPE, interned, true);
         str.interned = true;
         return str;
     }

--- a/src/org/python/core/PySyntaxError.java
+++ b/src/org/python/core/PySyntaxError.java
@@ -16,19 +16,14 @@ public class PySyntaxError extends PyException {
     String filename;
 
 
-    public PySyntaxError(String s, int line, int column, String text, String filename)
-    {
+    public PySyntaxError(String s, int line, int column, String text, String filename) {
         super(Py.SyntaxError);
-        //XXX: null text causes Java error, though I bet I'm not supposed to get null text.
-        if (text == null) {
-            text = "";
-        }
-        PyObject[] tmp = new PyObject[] {
-            Py.fileSystemEncode(filename), new PyInteger(line),
-            new PyInteger(column), new PyString(text)
-        };
+        // XXX: null text causes Java error, though I bet I'm not supposed to get null text.
+        PyString pyText = text == null ? Py.EmptyString : Py.newString(text);
+        PyObject[] tmp = new PyObject[] {Py.fileSystemEncode(filename), new PyInteger(line),
+                new PyInteger(column), pyText};
 
-        this.value = new PyTuple(new PyString(s), new PyTuple(tmp));
+        this.value = new PyTuple(Py.newString(s), new PyTuple(tmp));
 
         this.lineno = line;
         this.column = column;

--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -1,6 +1,16 @@
 // Copyright (c) Corporation for National Research Initiatives
 package org.python.core;
 
+import static org.python.core.RegistryKey.PYTHON_CACHEDIR;
+import static org.python.core.RegistryKey.PYTHON_CACHEDIR_SKIP;
+import static org.python.core.RegistryKey.PYTHON_CONSOLE;
+import static org.python.core.RegistryKey.PYTHON_CONSOLE_ENCODING;
+import static org.python.core.RegistryKey.PYTHON_IO_ENCODING;
+import static org.python.core.RegistryKey.PYTHON_IO_ERRORS;
+import static org.python.core.RegistryKey.PYTHON_MODULES_BUILTIN;
+import static org.python.core.RegistryKey.PYTHON_PATH;
+import static org.python.core.RegistryKey.USER_HOME;
+
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -49,8 +59,6 @@ import com.carrotsearch.sizeof.RamUsageEstimator;
 
 import jnr.posix.util.Platform;
 
-import static org.python.core.RegistryKey.*;
-
 
 /**
  * The "sys" module.
@@ -70,7 +78,7 @@ public class PySystemState extends PyObject
     public static final PyString version = new PyString(Version.getVersion());
 
     public static final PyTuple subversion =
-            new PyTuple(new PyString("Jython"), Py.newString(""), Py.newString(""));
+            new PyTuple(new PyString("Jython"), Py.EmptyString, Py.EmptyString);
 
     public static final int hexversion = ((Version.PY_MAJOR_VERSION << 24)
             | (Version.PY_MINOR_VERSION << 16) | (Version.PY_MICRO_VERSION << 8)

--- a/src/org/python/core/PyUnicode.java
+++ b/src/org/python/core/PyUnicode.java
@@ -155,7 +155,7 @@ public class PyUnicode extends PyString implements Iterable<Integer> {
      * @param isBasic true if it is known that only BMP characters are present.
      */
     private PyUnicode(PyType subtype, String string, boolean isBasic) {
-        super(subtype, "");
+        super(subtype, "", true);
         this.string = string;
         translator = isBasic ? BASIC : this.chooseIndexTranslator();
     }

--- a/src/org/python/core/SyspathArchive.java
+++ b/src/org/python/core/SyspathArchive.java
@@ -1,7 +1,10 @@
 package org.python.core;
-import java.io.*;
-import java.util.logging.Logger;
-import java.util.zip.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 @Untraversable
 public class SyspathArchive extends PyString {
@@ -20,29 +23,70 @@ public class SyspathArchive extends PyString {
         }
     }
 
-    SyspathArchive(ZipFile zipFile, String archiveName) {
+    SyspathArchive(ZipFile zipFile, String path) {
         // As a string-like object (on sys.path) an FS-encoded bytes object is expected
-        super(Py.fileSystemEncode(archiveName).getString());
+        // Equivalent to Py.fileSystemEncode(path) with super instead of PyString
+        super(TYPE,
+                PyString.charsFitWidth(path, 7) ? path : codecs.PyUnicode_EncodeUTF8(path, null),
+                true);
         this.zipFile = zipFile;
     }
 
+    /**
+     * Return a {@code SyspathArchive} wrapping the FS-encoded path into a ".zip" or ".jar" file
+     * (like "x/y/a.jar/b/c.x") and {@code ZipFile} archive representing the file part ("x/y/a.jar")
+     * of that path. This is guaranteed to be bytes-like (all chars &lt; 256). The method throws if
+     * the argument is malformed, meaning it does not contain ".zip" or ".jar", (terminally or
+     * followed by "/").
+     *
+     * @param path to represent
+     * @return SyspathArchive for the path
+     * @throws IOException if the argument is malformed
+     */
+    static SyspathArchive fromPath(String path) throws IOException {
+        // Check the name is properly formed and reduce it to the file part.
+        String archiveName = getArchiveName(path);
+        if (archiveName == null) {
+            throw new IOException(path);
+        } else {
+            ZipFile zipFile = new ZipFile(new File(archiveName));
+            if (PySystemState.isPackageCacheEnabled()) {
+                PySystemState.packageManager.addJar(archiveName, true);
+            }
+            return new SyspathArchive(zipFile, path);
+        }
+    }
+
+    /**
+     * Return the archive name extracted from a path like "x/y/a.jar/b/c.x" as a String, extracted
+     * from the path by truncation. Here the archive name would be the "x/y/a.jar" part. The method
+     * returns {@code null} if the argument is malformed, meaning it does not contain ".zip" or
+     * ".jar", (terminally or followed by "/").
+     *
+     * @param path to extract from
+     * @return archive name or {@code null} if the argument is does not contain ".zip" or ".jar"
+     */
     static String getArchiveName(String dir) {
         String lowerName = dir.toLowerCase();
         int idx = lowerName.indexOf(".zip");
         if (idx < 0) {
             idx = lowerName.indexOf(".jar");
         }
-        if (idx < 0) {
-            return null;
-        }
 
-        if (idx == dir.length() - 4) {
-            return dir;
+        if (idx >= 0) {
+            if (idx == dir.length() - 4) {
+                // Exactly ends with .zip or .jar
+                return dir;
+            } else {
+                // Continues, but must be /something
+                char ch = dir.charAt(idx + 4);
+                if (ch == File.separatorChar || ch == '/') {
+                    // Return only up toe the .jar/.zip (inclusive)
+                    return dir.substring(0, idx + 4);
+                }
+            }
         }
-        char ch = dir.charAt(idx+4);
-        if (ch == File.separatorChar || ch == '/') {
-            return dir.substring(0, idx+4);
-        }
+        // Malformed after all.
         return null;
     }
 

--- a/src/org/python/core/SyspathJavaLoader.java
+++ b/src/org/python/core/SyspathJavaLoader.java
@@ -222,7 +222,7 @@ public class SyspathJavaLoader extends ClassLoader {
         try {
             // this has the side effect of adding the jar to the PackageManager during the
             // initialization of the SyspathArchive
-            path = new SyspathArchive(sys.getPath(Py.fileSystemDecode(path)));
+            path = SyspathArchive.fromPath(sys.getPath(Py.fileSystemDecode(path)));
         } catch (Exception e) {
             return path;
         }

--- a/src/org/python/core/SyspathJavaLoader.java
+++ b/src/org/python/core/SyspathJavaLoader.java
@@ -222,7 +222,7 @@ public class SyspathJavaLoader extends ClassLoader {
         try {
             // this has the side effect of adding the jar to the PackageManager during the
             // initialization of the SyspathArchive
-            path = SyspathArchive.fromPath(sys.getPath(Py.fileSystemDecode(path)));
+            path = SyspathArchive.fromPath(sys.getPath(imp.fileSystemDecode(path)));
         } catch (Exception e) {
             return path;
         }

--- a/src/org/python/core/__builtin__.java
+++ b/src/org/python/core/__builtin__.java
@@ -21,7 +21,7 @@ import org.python.modules._functools._functools;
 @Untraversable
 class BuiltinFunctions extends PyBuiltinFunctionSet {
 
-    public static final PyObject module = Py.newString("__builtin__");
+    public static final PyObject module = PyString.fromInterned("__builtin__");
 
     public BuiltinFunctions(String name, int index, int argcount) {
         this(name, index, argcount, argcount);
@@ -686,7 +686,7 @@ public class __builtin__ {
     }
 
     public static PyObject input() {
-        return input(new PyString(""));
+        return input(Py.EmptyString);
     }
 
     public static PyString intern(PyObject obj) {
@@ -1139,7 +1139,7 @@ public class __builtin__ {
         }
     }
 
-    public static PyString __doc__zip = new PyString(
+    public static PyString __doc__zip = PyString.fromInterned(
         "zip(seq1 [, seq2 [...]]) -> [(seq1[0], seq2[0] ...), (...)]\n\n" +
         "Return a list of tuples, where each tuple contains the i-th element\n" +
         "from each of the argument sequences.  The returned list is\n" +

--- a/src/org/python/core/imp.java
+++ b/src/org/python/core/imp.java
@@ -88,7 +88,7 @@ public class imp {
     }
 
     /** A non-empty fromlist for __import__'ing sub-modules. */
-    private static final PyObject nonEmptyFromlist = new PyTuple(Py.newString("__doc__"));
+    private static final PyObject nonEmptyFromlist = new PyTuple(PyString.fromInterned("__doc__"));
 
     public static ClassLoader getSyspathJavaLoader() {
         return Py.getSystemState().getSyspathJavaLoader();

--- a/src/org/python/core/util/LimitedCache.java
+++ b/src/org/python/core/util/LimitedCache.java
@@ -1,0 +1,173 @@
+package org.python.core.util;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+/**
+ * Not for application use, a cache of recently given results from some costly function. This is
+ * only public so we can reach it from the run-time. The user sets a nominal size for the cache. The
+ * cache will grow to this size and a little more, but from time to time discard the "little more"
+ * on the basis of a score that depends on recency of use.
+ */
+public class LimitedCache<K, V> {
+
+    /**
+     * Threshold at which we re-normalise times using {@link #scaleClock()}. Big enough it hardly
+     * ever happens. Small enough to prevent overflow (much less than max integer).
+     */
+    private final int CLOCK_THRESHOLD = 10_000;
+
+    /** Maximum size of cache as requested. */
+    private final int limit;
+    /** Working upper limit (&gt; limit) at which to evict cached items. */
+    private final int upperLimit;
+    /** Increases with every operation (until renormalised by {@link #scaleClock()}). */
+    private int clock = 0;
+
+    /** Object that holds one cached value and its statistics. */
+    private static class Holder<T> {
+
+        final T value;
+        int used;
+
+        Holder(T value, int time) {
+            this.value = value;
+            this.used = time;
+        }
+
+        int score() {
+            return used;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("(%6d %.60s)", used, value);
+        }
+    }
+
+    private final HashMap<K, Holder<? extends V>> map;
+
+    /**
+     * Construct a cache that will hold (at least) the specified number of entries. (It will
+     * sometimes contain a few more so we don't have to scan the cache with every addition.)
+     *
+     * @param capacity the number of entries required
+     */
+    public LimitedCache(int capacity) {
+        this.limit = capacity;
+        this.upperLimit = capacity + capacity / 3 + 1;
+        this.map = new HashMap<>(this.upperLimit);
+    }
+
+    /**
+     * Get a value corresponding to the key, if it was previously cached.
+     *
+     * @param key against which cached
+     * @return the cached value or {@code null} if not present
+     */
+    public synchronized V get(K key) {
+        Holder<? extends V> h = map.get(key);
+        if (h != null) {
+            h.used = clock++;
+            if (clock >= CLOCK_THRESHOLD) {
+                scaleClock();
+            }
+            return h.value;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Add a value corresponding to a given key.
+     *
+     * @param key against which to cache the value
+     * @param value to store
+     */
+    public synchronized void add(K key, V value) {
+        map.computeIfAbsent(key, k -> new Holder<V>(value, clock++));
+        if (map.size() >= upperLimit) {
+            evictLowest();
+        }
+    }
+
+    /**
+     * Reduce the working size of the cache to at most the originally-specified capacity by removing
+     * low-scoring entries. We only do this when adding to the cache, and only then if the
+     * {@link #upperLimit} has been reached.
+     */
+    private void evictLowest() {
+        // Work out how many to discard: this can be zero and the call still useful.
+        final int N = Math.max(0, map.size() - limit);
+        // We collect the N worst (lowest) scores in ascending order.
+        int[] worst = new int[N];
+        Arrays.fill(worst, Integer.MAX_VALUE);
+        int disqualifyingScore = Integer.MIN_VALUE;
+
+        if (N > 0) {
+            // Sort scores into worst[], keeping lowest N.
+            for (Entry<K, Holder<? extends V>> e : map.entrySet()) {
+                Holder<? extends V> h = e.getValue();
+                int s = h.score();
+                if (s < worst[N - 1]) { // Is this going in the array at all?
+                    /*
+                     * It is. The process is the same as for shifting an array to the right by one,
+                     * except we start only once we see a score bigger than s. At that point the
+                     * "element in hand" is the score s to insert there.
+                     */
+                    int i = 0;
+                    while (i < N && s > worst[i]) {
+                        i++;
+                    }
+                    // Now start shifting the array. First in is s.
+                    while (i < N) {
+                        int t = worst[i];
+                        worst[i++] = s;
+                        s = t;
+                    }
+                }
+            }
+            disqualifyingScore = worst[N - 1];
+        }
+
+        // Remove everything scoring worst[N - 1] or lower
+        Iterator<Entry<K, Holder<? extends V>>> iter = map.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<K, Holder<? extends V>> e = iter.next();
+            Holder<? extends V> h = e.getValue();
+            if (h.score() <= disqualifyingScore) {
+                iter.remove();
+            }
+        }
+    }
+
+    /**
+     * Scale down all the last used times and the current clock. We do this because otherwise the
+     * clock increases indefinitely and theoretically could overflow, at which point the algorithm
+     * breaks. We don't do this very often: only when {@link #clock} reached
+     * {@link #CLOCK_THRESHOLD}.
+     */
+    private void scaleClock() {
+        for (Holder<? extends V> h : map.values()) {
+            h.used >>>= 1;
+        }
+        // And set the time back on the clock too
+        clock >>>= 1;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+        b.append("LimitedCache [clock=").append(clock);
+        b.append(", size=").append(map.size());
+        b.append(" (").append(limit);
+        b.append(", ").append(upperLimit);
+        b.append(")]\n");
+        for (Holder<? extends V> h : map.values()) {
+            b.append(h.toString()).append("\n");;
+        }
+        return b.toString();
+    }
+}

--- a/src/org/python/core/util/StringCounter.java
+++ b/src/org/python/core/util/StringCounter.java
@@ -1,0 +1,90 @@
+package org.python.core.util;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * <b>Not for application use</b>, this class may be used to count how many times a {@code String}
+ * occurs a point in the runtime. We use this to investigate optimisations of the handling of
+ * strings in the runtime, principally to avoid checks for byte-nature where that is already known.
+ */
+public class StringCounter {
+
+    private static HashMap<String, Integer> counts = new HashMap<String, Integer>(1000);
+
+    /**
+     * Count this occurrence.
+     *
+     * @param s to count
+     */
+    public synchronized void count(String s) {
+        Integer n = counts.getOrDefault(s, 0);
+        counts.put(s, n + 1);
+    }
+
+    /**
+     * Report the top {@code n} counts.
+     *
+     * @param n number of counts to retrieve
+     * @return counts of the top {@code n} strings.
+     */
+    public synchronized Map<String, Integer> top(int n) {
+        // We perform an insertion sort to a list of size up to n
+        ArrayList<String> keys = new ArrayList<>();
+        ArrayList<Integer> vals = new ArrayList<>();
+        // For speed, we cache here the lowest value on the list
+        int min = 0, len = 0;
+
+        for (String key : counts.keySet()) {
+            int val = counts.get(key);
+            if (val > min) {
+                // We will add (key, val) to the list.
+                int p = len - 1;
+
+                // Work back from the (low value) end until vals[i] > val.
+                for (; p >= 0; --p) {
+                    if (vals.get(p) > val) {
+                        break;
+                    }
+                }
+
+                // Insert after the entry that stopped us.
+                p += 1;
+
+                // p is 0 if we dropped out of the loop at the end.
+                keys.add(p, key);
+                vals.add(p, val);
+
+                if (len == n) {
+                    // The list was already n-long so discard from the end.
+                    keys.remove(n);
+                    vals.remove(n);
+                    // Raise the minimum for entry.
+                    min = vals.get(n - 1);
+                } else {
+                    // Count the increase.
+                    len += 1;
+                }
+            }
+        }
+
+        // Zip the resulting arrays into a map
+        Map<String, Integer> m = new LinkedHashMap<>();
+        for (int i = 0; i < keys.size(); i++) {
+            m.put(keys.get(i), vals.get(i));
+        }
+        return m;
+    }
+
+    /** Report the top n counts. */
+    public void top(int n, PrintStream out) {
+        for (Map.Entry<String, Integer> e : top(n).entrySet()) {
+            String key = e.getKey();
+            out.printf("%5d  \"%.60s%s\"\n", e.getValue(), key, key.length() > 60 ? "..." : "");
+        }
+        out.println();
+    }
+}


### PR DESCRIPTION
When constructing a `PyString`, we check that a Java String leads to an acceptable. This is fairly costly so we'd like to avoid doing it when we already know the answer. These are tweaks aimed at doing that.

An important case occurs where compiled code calls `PyString.fromInterned`, which it does every time we encounter `str` constant and often for identifiers. The compiler guarantees these are bytes.

More to come. (Probably shouldn't squash-merge as we may want to revert an individual optimisation.)