### PR TITLE
Support vararg constructors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,9 +19,9 @@ New Features
       variable (GH-128).
 
     - Under PR GH-101, the matching of sequence arguments to the parameters of
-      Java methods is improved. A Java varargs parameter does not match a final
-      sequence in the call if an array parameter could do so. (Thanks Peter
-      Holloway.)
+      Java methods is improved (and in constructors under GH-201). A Java
+      varargs parameter does not match a final sequence in the call if an array
+      parameter could do so. (Thanks Peter Holloway.)
 
     - array.array itemsize of unsigned types is now the same as their signed
       counterparts, where previously it was mostly double. Internal
@@ -39,7 +39,7 @@ New Features
 
 
 Jython 2.7.3b2-DEV Bugs fixed
-    - [ GH- ] 
+    - [ GH-201 ] Support vararg constructors
 
 Jython 2.7.3b1 Bugs fixed
     - [ GH-192 ] PyString with non-byte value in formatting of collections

--- a/src/org/python/core/PyReflectedConstructor.java
+++ b/src/org/python/core/PyReflectedConstructor.java
@@ -21,7 +21,7 @@ public class PyReflectedConstructor extends PyReflectedFunction {
     }
 
     private ReflectedArgs makeArgs(Constructor<?> m) {
-        return new ReflectedArgs(m, m.getParameterTypes(), m.getDeclaringClass(), true);
+        return new ReflectedArgs(m, m.getParameterTypes(), m.getDeclaringClass(), true, m.isVarArgs());
     }
 
     public void addConstructor(Constructor<?> m) {


### PR DESCRIPTION
Checking if constructors are vararg methods allows autoboxing to be used for classes such as
```java
public class Foo {
    public Foo(String name, int... numbers) {
        // ...
    }
}
```