### PR TITLE
Explicitly choose Python 3.8 in build

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,12 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          # This has to match the language version we're targeting
+          python-version: '3.8'
+
       - name: Unit test with Gradle
         run: ./gradlew --no-daemon test
 


### PR DESCRIPTION
I knew this would bite eventually and it has. The default Python became 3.10, so of course it generates the wrong byte code in the wrong place.