### PR TITLE
Hold import lock only in getCodecState to avoid deadlock

### DIFF
--- a/ACKNOWLEDGMENTS
+++ b/ACKNOWLEDGMENTS
@@ -193,6 +193,7 @@ Jython in ways large and small, in no particular order:
     Joe Shannon
     Dominik Broj
     shoaniki (GitHub name)
+    Zhihong (Ted) Yu
 
 Local Variables:
 mode: indented-text

--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -368,7 +368,7 @@ public class PySystemState extends PyObject
                 if (codecState == null) {
                     codecState = new codecs.CodecState();
                     // we have the importLock locked
-                    imp.load("encodings", false);
+                    imp.load("encodings");
                 }
             } catch (PyException exc) {
                 if (exc.type != Py.ImportError) {

--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;

--- a/src/org/python/core/imp.java
+++ b/src/org/python/core/imp.java
@@ -1008,12 +1008,12 @@ public class imp {
      * Load the module by name. Upon loading the module it will be added to sys.modules.
      *
      * @param name the name of the module to load
-     * @param needToLock true if importLock should be locked
      * @return the loaded module
      */
-    public static PyObject load(String name, boolean needToLock) {
+    public static PyObject load(String name) {
         checkName(name);
         ReentrantLock importLock = Py.getSystemState().getImportLock();
+        boolean needToLock = !importLock.isLocked();
         if (needToLock) {
             importLock.lock();
         }
@@ -1024,15 +1024,6 @@ public class imp {
                 importLock.unlock();
             }
         }
-    }
-    /**
-     * Load the module by name. Upon loading the module it will be added to sys.modules.
-     *
-     * @param name the name of the module to load
-     * @return the loaded module
-     */
-    public static PyObject load(String name) {
-        return load(name, true);
     }
 
     /**

--- a/src/org/python/core/imp.java
+++ b/src/org/python/core/imp.java
@@ -1008,17 +1008,31 @@ public class imp {
      * Load the module by name. Upon loading the module it will be added to sys.modules.
      *
      * @param name the name of the module to load
+     * @param needToLock true if importLock should be locked
      * @return the loaded module
      */
-    public static PyObject load(String name) {
+    public static PyObject load(String name, boolean needToLock) {
         checkName(name);
         ReentrantLock importLock = Py.getSystemState().getImportLock();
-        importLock.lock();
+        if (needToLock) {
+            importLock.lock();
+        }
         try {
             return import_first(name, new StringBuilder());
         } finally {
-            importLock.unlock();
+            if (needToLock) {
+                importLock.unlock();
+            }
         }
+    }
+    /**
+     * Load the module by name. Upon loading the module it will be added to sys.modules.
+     *
+     * @param name the name of the module to load
+     * @return the loaded module
+     */
+    public static PyObject load(String name) {
+        return load(name, true);
     }
 
     /**

--- a/src/org/python/core/imp.java
+++ b/src/org/python/core/imp.java
@@ -1013,16 +1013,11 @@ public class imp {
     public static PyObject load(String name) {
         checkName(name);
         ReentrantLock importLock = Py.getSystemState().getImportLock();
-        boolean needToLock = !importLock.isLocked();
-        if (needToLock) {
-            importLock.lock();
-        }
+        importLock.lock();
         try {
             return import_first(name, new StringBuilder());
         } finally {
-            if (needToLock) {
-                importLock.unlock();
-            }
+            importLock.unlock();
         }
     }
 


### PR DESCRIPTION
Recently we encountered deadlock w.r.t. python import.
```
"http-nio-8080-exec-9":
  waiting for ownable synchronizer 0x00000007bf84aa00, (a java.util.concurrent.locks.ReentrantLock$NonfairSync),
  which is held by "http-nio-8080-exec-7"

"http-nio-8080-exec-7":
        at org.python.core.PySystemState.getCodecState(PySystemState.java:357)
        - waiting to lock <0x00000007bf8492b0> (a org.python.core.PySystemState)
        at org.python.core.codecs.getDefaultEncoding(codecs.java:38)
```
 `http-nio-8080-exec-7` was calling imp.createFromCode() which held `SystemState().getImportLock()`. Then `http-nio-8080-exec-7` tried to call `PySystemState.getCodecState`, waiting on `PySystemState`'s lock.
```
"http-nio-8080-exec-9":
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000007bf84aa00> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
        at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
        at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
        at org.python.core.imp.load(imp.java:719)
        at org.python.core.PySystemState.getCodecState(PySystemState.java:360)
        - locked <0x00000007bf8492b0> (a org.python.core.PySystemState)
```
When `http-nio-8080-exec-9` called `imp.load` which needed to lock the import lock, deadlock formed.

This PR changes the locking in `PySystemState#getCodecState`. We only take importLock.
With this change, the deadlock shown in the stack trace cannot happen.