### PR TITLE
Support Java 17 in v3.8

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 
 jobs:
 
-  unit-tests-Ubuntu-jdk-11:
+  unit-tests-Ubuntu-jdk-17:
 
     runs-on: ubuntu-latest
 
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
 
       - name: Set up Python 3.8

--- a/build-tools/build-tools.gradle
+++ b/build-tools/build-tools.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.+'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.+'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ allprojects {
 
     apply plugin: 'java'
     // We support Java 11 onwards officially.
-    sourceCompatibility = '11'
+    sourceCompatibility = '17'
 
     // Same configuiration all sub-projects
     tasks.withType(JavaCompile) {
@@ -53,7 +53,7 @@ allprojects {
         options.deprecation = true
 
         // Use only public API
-        options.compilerArgs.addAll(['--release', '11'])
+        options.compilerArgs.addAll(['--release', '17'])
     }
 
     tasks.withType(Javadoc) {

--- a/core/core.gradle
+++ b/core/core.gradle
@@ -13,9 +13,9 @@ dependencies {
     //implementation 'org.ow2.asm:asm:9.+'
 
     // JUnit 5 dependencies
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.+'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.+'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.+'
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Let's run on the latest LTS.

- Update Gradle (have to).
- Update Java (in Gradle and the CI).
- Any dependencies looking cobwebby?

Expect to merge without much delay as uncontroversial and what I really want to do is advance the target Python to 3.11.