### PR TITLE
Disable failing test in test_urllib2net

### DIFF
--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -192,8 +192,7 @@ class OtherNetworkTests(unittest.TestCase):
             opener.open(request)
             self.assertEqual(request.get_header('User-agent'),'Test-Agent')
 
-    # CPython 2.7 has unittest.skip('XXX: http://www.imdb.com is gone')
-    # ... but it isn't
+    @unittest.skip('http://www.imdb.com is gone') # from CPython 2.7
     def test_sites_no_connection_close(self):
         # Some sites do not send Connection: close header.
         # Verify that those work properly. (#issue12576)


### PR DESCRIPTION
The site used no longer responds as needed for the test. (We're just copying CPython since 2.7.16 in disabling it.)