### PR TITLE
Restore test_socket IDNATest with working domain name

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4,9 +4,6 @@ import unittest
 from test import test_support
 
 import errno
-import gc
-import jarray
-import os
 import Queue
 import platform
 import pprint

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -882,6 +882,8 @@ class TestSocketOptions(unittest.TestCase):
         except Exception, x:
             self.fail("Inherited option should not have raised exception: %s" % str(x))
 
+@unittest.skipIf(test_support.is_jython_posix,
+                 "Failing, possible race during close()-open().")
 class TestSupportedOptions(TestSocketOptions):
 
     def testSO_BROADCAST(self):
@@ -930,8 +932,6 @@ class TestSupportedOptions(TestSocketOptions):
         self._testOption(socket.SOL_SOCKET, socket.SO_SNDBUF, [1024, 4096, 16384])
         self._testInheritedOption(socket.SOL_SOCKET, socket.SO_SNDBUF, [1024, 4096, 16384])
 
-    @unittest.skipIf(test_support.is_jython_posix,
-                     "Failing (tcp_server case), possible race with close().")
     def testSO_TIMEOUT(self):
         self.test_udp        = 1
         self.test_tcp_client = 1

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -6,6 +6,7 @@ from test import test_support
 import errno
 import gc
 import jarray
+import os
 import Queue
 import platform
 import pprint
@@ -932,6 +933,8 @@ class TestSupportedOptions(TestSocketOptions):
         self._testOption(socket.SOL_SOCKET, socket.SO_SNDBUF, [1024, 4096, 16384])
         self._testInheritedOption(socket.SOL_SOCKET, socket.SO_SNDBUF, [1024, 4096, 16384])
 
+    @unittest.skipIf(test_support.is_jython_posix,
+                     "Failing (tcp_server case), possible race with close().")
     def testSO_TIMEOUT(self):
         self.test_udp        = 1
         self.test_tcp_client = 1

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2397,8 +2397,11 @@ class UnicodeTest(ThreadedTCPSocketTest):
 
 class IDNATest(unittest.TestCase):
 
+    # This site must exist in DNS as an IDN, hopefully with a long future.
+    DOMAIN = u'\u043c\u0430\u0442\u0435\u043c\u0430\u0442\u0438\u043a\u0430.\u0443\u043a\u0440'
+
     def testGetAddrInfoIDNAHostname(self):
-        idna_domain = u"al\u00e1n.com"
+        idna_domain = IDNATest.DOMAIN
         if socket.supports('idna'):
             try:
                 addresses = socket.getaddrinfo(idna_domain, 80)
@@ -2416,7 +2419,7 @@ class IDNATest(unittest.TestCase):
                 self.fail("Non ascii domain '%s' should have raised UnicodeEncodeError: no exception raised" % repr(idna_domain))
 
     def testAddrTupleIDNAHostname(self):
-        idna_domain = u"al\u00e1n.com"
+        idna_domain = IDNATest.DOMAIN
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if socket.supports('idna'):
             try:

--- a/build.xml
+++ b/build.xml
@@ -1511,7 +1511,6 @@ The text for an official release would continue like ...
             <arg value="test_py_compile"/> <!-- test_relative_path (on osx) -->
             <arg value="test_select_new"/>
             <arg value="test_smtpnet"/>
-            <arg value="test_socket"/>
         </exec>
     </target>
 
@@ -1532,7 +1531,6 @@ The text for an official release would continue like ...
             <arg value="test_os_jy"/> <!-- locale command (on git bash) -->
             <arg value="test_select_new"/>
             <arg value="test_smtpnet"/>
-            <arg value="test_socket"/>
         </exec>
     </target>
 


### PR DESCRIPTION
This test was failing locally (and excluded from CI) because the site used in the test did not exist and `testGetAddrInfoIDNAHostname` must resolve it in DNS.

I'm re-enabling `test_socket` in CI, experimentally, in case this was the only reason to suppress it.