### PR TITLE
CI: Set read-only permissions on GitHub Workflows

### DIFF
--- a/.github/workflows/ant-javatest.yml
+++ b/.github/workflows/ant-javatest.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/ant-regrtest.yml
+++ b/.github/workflows/ant-regrtest.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -5,6 +5,9 @@ name: codespell
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   codespell-text:
 

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
Resolves #241 by defining a read-only permission for all workflow files at a root level.