### PR TITLE
Update README concerning CPython compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,30 @@ the implementation of Python in Java.
 Only version 2.7 of Python can be supported at present
 (but watch this space for a 3.x version).
 
-Along with good (not perfect!) language
-and runtime compatibility with CPython 2.7,
-Jython 2.7 provides substantial support of the Python ecosystem.
-This includes built-in support of *pip/setuptools*
-(you can use `bin/pip` if the targets do not include `C` extensions)
-and a native launcher for Windows (`bin/jython.exe`)
+## Compatibility
+
+Jython provides good compatibility with Python 2.7 *the language*.
+Also, a high proportion of the standard library is included,
+taken from late versions of CPython (around 2.7.13).
+Some standard library modules have a Jython-specific implementation
+that has not kept pace with its CPython counterpart.
+
+Jython 2.7 support for the Python ecosystem
+includes built-in support of *pip/setuptools*.
+You can use `bin/pip` if the targets do not include `C` extensions.
+There is a native launcher for Windows (`bin/jython.exe`)
 that works essentially like the `python` command.
 
 Jim Baker presented a talk at PyCon 2015 about Jython 2.7,
 including demos of new features: https://www.youtube.com/watch?v=hLm3garVQFo
+
+## Support
+
+Python 2.7 (the language) is no longer supported by the PSF.
+Running on Jython should not be considered an alternative to porting your
+application to Python 3, due to the limitations cited here
+and the small amount of effort available to support 2.7.x.
+Jython 2.7 is offered for continuity because a 3.x is not yet available.
 
 See [ACKNOWLEDGMENTS](ACKNOWLEDGMENTS) for details about Jython's copyright,
 license, contributors, and mailing lists.
@@ -31,6 +45,8 @@ The project uses Git for version-control,
 and the master repository is at https://github.com/jython/jython,
 You should clone this repository to create a buildable copy of the latest state
 of the Jython source.
+Start a new branch for any bug-fix or experimentation you plan.
+
 The previously authoritative repository at https://hg.python.org/jython is not now in use,
 remaining frozen at v2.7.2.
 
@@ -47,13 +63,14 @@ that you may run from the check-out root with:
 ```
 dist/bin/jython
 ```
-Other `ant` targets exist, notably `clean`, and `jar`.
+Other `ant` targets exist, notably `clean`, `javatest` and `jar`.
 
 You can test your build of Jython (by running the regression tests),
 with the command:
 ```
 dist/bin/jython -m test.regrtest -e -m regrtest_memo.txt
 ```
+or by invoking the Ant target `regrtest`.
 
 ### Build an installer using `ant`
 
@@ -74,8 +91,7 @@ For the console version. (A `--help` option gives you the full story.)
 
 ### Build a JAR using Gradle
 
-Experimentally, we have a Gradle build that results in a family of JARs,
-and a POM.
+We have a Gradle build that results in a family of JARs and a POM.
 This is intended to provide the Jython core in a form that Gradle and Maven
 users can consume as a dependency.
 Invoke this with:
@@ -88,5 +104,3 @@ Whereas the JARs delivered by the installer are somewhat "fat",
 embedding certain dependencies in shaded (renamed) form,
 the JAR from the Gradle build is "spare"
 and cites its dependencies externally through a POM.
-The project would like to know if this is being done suitably
-for downstream use.

--- a/README.txt
+++ b/README.txt
@@ -8,7 +8,8 @@ This is @readme.release@ release of version @jython.version.short@ of Jython.
 Along with language and runtime compatibility with CPython 2.7, Jython 2.7
 provides substantial support of the Python ecosystem. This includes built-in
 support of pip/setuptools (you can use with bin/pip) and a native launcher
-for Windows (bin/jython.exe).
+for Windows (bin/jython.exe). Python 2.7 is out of support. Running on Jython
+should not be considered an alternative to porting to Python 3.
 
 Jim Baker presented a talk at PyCon 2015 about Jython 2.7, including demos
 of new features: https://www.youtube.com/watch?v=hLm3garVQFo


### PR DESCRIPTION
A risk has been raised that some CPython 2 users will adopt Jython as a way to avoid migrating to Python 3. This would be a bad idea for any moderately complex application, as is likely to be obvious immediately one tries it (C extensions or other stdlib incompatibilities).

It costs little to be explicit that we make no such claim, and what we mean by "Python for the JVM". There is room on the GitHub project home to explain but we should be as brief as possible in the installation README.

We can improve a few other details too.