### PR TITLE
Changing grammar for decorators that don't have parenthesis

### DIFF
--- a/grammar/Python.g
+++ b/grammar/Python.g
@@ -488,7 +488,7 @@ decorator
       RPAREN
     |
       {
-          $etype = $dotted_attr.etype;
+          $etype = actions.makeCall($LPAREN, $dotted_attr.etype);
       }
     ) NEWLINE
     ;


### PR DESCRIPTION
Processing as a `CALL`  instead of an `Attribute` for the case when decorators don't have parenthesis.

```python
@decomaker(argA, argB, ...)
def func(arg1, arg2, ...):
    pass
```
This is equivalent to:
```python
func = decomaker(argA, argB, ...)(func)
```
Ref: [PEP 318 – Decorators for Functions and Methods](https://peps.python.org/pep-0318/)

Therefore, using `@decorator` is like a `CALL`.

Same PR as #267 but targeting `master` branch.