### PR TITLE
Correct handling of space in JBoss URL test

### DIFF
--- a/.github/workflows/ant-javatest.yml
+++ b/.github/workflows/ant-javatest.yml
@@ -41,5 +41,5 @@ jobs:
       run: ant -noinput -buildfile build.xml developer-build
 
     - name: Unit test with Ant on ${{ matrix.os }}
-      run: ant -noinput -buildfile build.xml javatest
+      run: ant javatest-ci
 

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Build with Ant
       run: ant -noinput -buildfile build.xml
 
+    - name: Run Java tests with Ant
+      run: ant javatest
+
     - name: Show JVM arguments when launched by script
       run: dist/bin/jython -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
 

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -39,7 +39,7 @@ jobs:
       run: ant -noinput -buildfile build.xml
 
     - name: Run Java tests with Ant
-      run: ant javatest
+      run: ant javatest-ci
 
     - name: Show JVM arguments when launched by script
       run: dist/bin/jython -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -19,7 +19,8 @@ jobs:
 
   launcher-test-macos-jdk8:
 
-    runs-on: macos-latest
+    # Pin at 12 for Python 2 support
+    runs-on: macos-12
 
     steps:
     - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 Jython NEWS
 
+
 The features new in a given version are listed at the head of the section for
 the final release of that version. Bugs fixed are listed under the next release
 (frequently a beta) after they were fixed.
@@ -22,6 +23,7 @@ Jython 2.7.4a1 Bugs fixed
     - [ GH-269 ] Upgrade Google Guava to 32.0.1 (CVE-2023-2976)
     - [ GH-264 ] Create a security policy
     - [ GH-254 ] Regression in socket.socket.sendall for sending Unicode
+    - [ GH-247 ] PySystemStateTest fails on Mac
     - [ GH-245 ] Document download/binaries location
 
 
@@ -322,7 +324,7 @@ Jython 2.7.1rc1
     - [ 2527 ] cStringIO throws IllegalArgumentException with non-ASCII values
     - [ 2511 ] Percent operator calls __getattr__('__getitem__')
     - [ FM-28 ] zipimporter supports multi-byte characters in pathnames
-    - [ 2228 ] Re-use "makeCompiledFilename" function where possible
+    - [ 2228 ] Reuse "makeCompiledFilename" function where possible
     - [ 608632 ] __doc__foo should accept java String
     - [ 2523 ] defaultdict.__getitem__() does not propagate exceptions raised by calling
                default_factory
@@ -1143,7 +1145,7 @@ Jython 2.5.0 a0 - rc2
     - [ 1222918 ] -C NONE causes exception
     - [ 1604258 ] copy.copy doesn't work on subclasses of newstyle classes
     - [ 1798554 ] zlib.__doc__ is not showing any output
-    - [ 1798556 ] patch for :[ 1798554 ] zlib.__doc__ is not showing any outpu
+    - [ 1798556 ] patch for :[ 1798554 ] zlib.__doc__ is not showing any output
     - [ 1003 ] struct packing inconsistent with CPython
     - [ 1052 ] __int__ returning PyLong = ClassCastException mayhem
     - [ 1167 ] random.py in standard library is broken in 2.5beta0

--- a/build.xml
+++ b/build.xml
@@ -1278,7 +1278,7 @@ The text for an official release would continue like ...
     <target name="test" depends="clean-test, javatest, launchertest, regrtest, modjytest"
         description="run all the tests"/>
 
-    <target name="singlejavatest" depends="compile, expose"
+    <target name="singlejavatest" depends="compile-test, expose"
         description="run a single JUnit test (specify with -Dtest=classname)">
         <junit haltonfailure="true" fork="true">
             <formatter type="brief" usefile="false"/>
@@ -1342,6 +1342,25 @@ The text for an official release would continue like ...
             </classpath>
             <batchtest todir="${junit.reports}">
                 <fileset dir="${test.source.dir}" includes="org/python/tests/imp/*Test*.java">
+                </fileset>
+            </batchtest>
+        </junit>
+    </target>
+
+    <target name="javatest-ci" depends="developer-build">
+        <junit haltonfailure="true" fork="true">
+            <formatter type="brief" usefile="false"/>
+            <sysproperty key="python.home" value="${dist.dir}"/>
+            <sysproperty key="python.test.source.dir" value="${test.source.dir}"/>
+            <classpath refid="test.classpath"/>
+            <batchtest skipNonTests="true">
+                <fileset dir="${test.source.dir}" includes="**/*Test*.java">
+                    <exclude name="**/InterpTestCase.java" />
+                    <exclude name="**/jythonTest*" /> <!-- Must run interactively -->
+                    <exclude name="org/python/antlr/**" />
+                    <exclude name="org/python/tests/imp/**" /> <!-- See javatest-import -->
+                    <exclude name=".classpath" />
+                    <exclude name=".project" />
                 </fileset>
             </batchtest>
         </junit>

--- a/tests/java/org/python/core/PySystemStateTest.java
+++ b/tests/java/org/python/core/PySystemStateTest.java
@@ -129,7 +129,7 @@ public class PySystemStateTest extends TestCase {
             String result = Py.getJarFileNameFromURL(url);
             assertEquals("C:\\some_dir\\some.jar", result);
             // jboss url to decode
-            file = "/C:/some dir/some.jar" + classPart;  // FIXME: does not match expected result
+            file = "/C:/some%20dir/some.jar" + classPart;
             url = new URL(protocol, host, port, file, handler);
             assertEquals("vfszip:/C:/some%20dir/some.jar" + classPart, url.toString());
             result = Py.getJarFileNameFromURL(url);
@@ -154,7 +154,7 @@ public class PySystemStateTest extends TestCase {
             String result = Py.getJarFileNameFromURL(url);
             assertEquals("/some_dir/some.jar", result);
             // jboss url to decode
-            file = "/some dir/some.jar" + classPart;  // FIXME: does not match expected result
+            file = "/some%20dir/some.jar" + classPart;
             url = new URL(protocol, host, port, file, handler);
             assertEquals("vfszip:/some%20dir/some.jar" + classPart, url.toString());
             result = Py.getJarFileNameFromURL(url);

--- a/tests/java/org/python/core/PySystemStateTest.java
+++ b/tests/java/org/python/core/PySystemStateTest.java
@@ -154,7 +154,7 @@ public class PySystemStateTest extends TestCase {
             String result = Py.getJarFileNameFromURL(url);
             assertEquals("/some_dir/some.jar", result);
             // jboss url to decode
-            file = "/some%20dir/some.jar" + classPart;
+            file = "/some dir/some.jar" + classPart;  // FIXME: does not match expected result
             url = new URL(protocol, host, port, file, handler);
             assertEquals("vfszip:/some%20dir/some.jar" + classPart, url.toString());
             result = Py.getJarFileNameFromURL(url);

--- a/tests/java/org/python/core/PySystemStateTest.java
+++ b/tests/java/org/python/core/PySystemStateTest.java
@@ -129,7 +129,7 @@ public class PySystemStateTest extends TestCase {
             String result = Py.getJarFileNameFromURL(url);
             assertEquals("C:\\some_dir\\some.jar", result);
             // jboss url to decode
-            file = "/C:/some%20dir/some.jar" + classPart;
+            file = "/C:/some dir/some.jar" + classPart;  // FIXME: does not match expected result
             url = new URL(protocol, host, port, file, handler);
             assertEquals("vfszip:/C:/some%20dir/some.jar" + classPart, url.toString());
             result = Py.getJarFileNameFromURL(url);


### PR DESCRIPTION
At present, this PR definitely doesn't fix #247. It simply adds the `javatest` target to the tests we run on macOS, to see if it really fails.

I don't have a machine at home on which I can reproduce the test failure.