### PR TITLE
Rely on system Python 2 in launcher test

### DIFF
--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -30,10 +30,25 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '2.7'
+    # We have to install Python 2.7 explicitly
+    # Based on https://github.com/LizardByte/setup-python-action specialised for MacOS
+    - name: Set up Python 2
+      shell: bash
+      run: |
+         # Use the default Python to install pip2.7
+         python -V
+         curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+         python get-pip.py
+         # Get a 2.7 virtual environment
+         python -m pip install virtualenv
+         venv="/tmp/python27/venv"
+         python -m virtualenv ${venv}
+         source ${venv}/bin/activate
+         # See what we got
+         python -V
+         echo "${venv}/bin" >> $GITHUB_PATH
+         python -V
+
 
     - name: Set up JDK 8
       uses: actions/setup-java@v3

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -19,7 +19,7 @@ jobs:
 
   launcher-test-macos-jdk8:
 
-    # Pin at 12 for Python 2 support
+    # Pin at 12 for Python 2 available
     runs-on: macos-12
 
     steps:
@@ -29,6 +29,11 @@ jobs:
     - run: git config --global core.autocrlf input
 
     - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '2.7'
 
     - name: Set up JDK 8
       uses: actions/setup-java@v3
@@ -46,11 +51,11 @@ jobs:
       run: dist/bin/jython -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
 
     - name: Show JVM arguments when launched by Python
-      run: python2 dist/bin/jython.py -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
+      run: python dist/bin/jython.py -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
 
     - name: Regression tests for invocation of the interpreter with various command line arguments
       run: dist/bin/jython -m test.test_cmd_line
 
     - name: Regression tests for command line execution of scripts
-      run: python2 dist/bin/jython.py -m test.test_cmd_line_script
+      run: python dist/bin/jython.py -m test.test_cmd_line_script
 

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -30,26 +30,6 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    # We have to install Python 2.7 explicitly
-    # Based on https://github.com/LizardByte/setup-python-action specialised for MacOS
-    - name: Set up Python 2
-      shell: bash
-      run: |
-         # Use the default Python to install pip2.7
-         python -V
-         curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-         python get-pip.py
-         # Get a 2.7 virtual environment
-         python -m pip install virtualenv
-         venv="/tmp/python27/venv"
-         python -m virtualenv ${venv}
-         source ${venv}/bin/activate
-         # See what we got
-         python -V
-         echo "${venv}/bin" >> $GITHUB_PATH
-         python -V
-
-
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
@@ -66,11 +46,15 @@ jobs:
       run: dist/bin/jython -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
 
     - name: Show JVM arguments when launched by Python
-      run: python dist/bin/jython.py -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
+      run: |
+          python -V
+          python dist/bin/jython.py -c 'from java.lang.management import ManagementFactory; print ManagementFactory.getRuntimeMXBean().getInputArguments()'
 
     - name: Regression tests for invocation of the interpreter with various command line arguments
       run: dist/bin/jython -m test.test_cmd_line
 
     - name: Regression tests for command line execution of scripts
-      run: python dist/bin/jython.py -m test.test_cmd_line_script
+      run: |
+          python -V
+          python dist/bin/jython.py -m test.test_cmd_line_script
 


### PR DESCRIPTION
Seems like you may have to to get reliable results.

It worked once:
https://github.com/jython/jython/actions/runs/6691152394/job/18177840624
but not the second time (after only a squash-merge). :(
https://github.com/jython/jython/actions/runs/6691364484/job/18178452814
