### PR TITLE
Add overloaded method resolution test/demo

### DIFF
--- a/Lib/test/test_joverload.py
+++ b/Lib/test/test_joverload.py
@@ -7,6 +7,7 @@ import sys
 import unittest
 
 import java
+from java.lang import Float, Double, Integer, Long, Boolean
 from java.util import ArrayList
 from javatests import JOverload, Reflection
 from org.python.core import PyReflectedFunction
@@ -217,6 +218,20 @@ class ComplexOverloadingTests(unittest.TestCase):
         # Note in Java these match both foo(int,int...) and foo(int...):
         self.assertEqual(over.foo(1), "int, int...")
         self.assertEqual(over.foo(1, 2, 3, 4), "int, int...")
+
+    def test_method_most_specific(self):
+        over = Reflection.Overloaded()
+        # Java constructors may be used to specify argument types
+        self.assertEqual(over.bar(Integer(1)), "int")
+        self.assertEqual(over.bar(Long(1)), "long")
+        self.assertEqual(over.bar(Boolean(True)), "boolean")
+        self.assertEqual(over.bar(Float(1.)), "float")
+        self.assertEqual(over.bar(Double(1.)), "Number")
+        # For better or worse (for 25yrs), function returns are coerced to Python:
+        self.assertEqual(over.bar(Integer.valueOf(1)), "long")
+        self.assertEqual(over.bar(Boolean.valueOf(True)), "long")
+        self.assertEqual(over.bar(Float.valueOf(1.)), "float")
+        self.assertEqual(over.bar(Double(1.).valueOf(1.)), "float")
 
     def test_complex(self):
         o = Reflection.Overloaded()

--- a/tests/java/javatests/Reflection.java
+++ b/tests/java/javatests/Reflection.java
@@ -157,6 +157,26 @@ public class Reflection {
             return "int...";
         }
 
+        public String bar(int a) {
+            return "int";
+        }
+
+        public String bar(long a) {
+            return "long";
+        }
+
+        public String bar(boolean a) {
+            return "boolean";
+        }
+
+        public String bar(float a) {
+            return "float";
+        }
+
+        public String bar(Number a) {
+            return "Number";
+        }
+
         public PyObject __call__(float x) {
             return dump(x);
         }


### PR DESCRIPTION
The magic around the order of search and method resolution in Jython does not fully reproduce Java's rules. We add these tests as a reminder of the behaviour, and a trip-wire in case we unintentionally go against a precedent of 25 years.