### PR TITLE
Increase run-times in test.test_timeit

### DIFF
--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -11,12 +11,10 @@ NUMBER = 10000  # Of times to execute in each test
 class TestTimeit(unittest.TestCase):
 
     def test_oct(self):
-        timing = timeit.Timer('for i in xrange(10): oct(i)', 'gc.enable()').timeit(number=NUMBER)
-        print timing
+        timing = timeit.Timer('for i in xrange(100): oct(i)', 'gc.enable()').timeit(number=NUMBER)
         self.assertGreater(timing, 0.)
 
         timing_vector = timeit.Timer('for i in xrange(10): oct(i)').repeat(number=NUMBER)
-        print timing_vector
         self.assertEqual(len(timing_vector), 3)
         self.assertGreater(min(timing_vector), 0.)
 
@@ -29,11 +27,9 @@ class TestTimeit(unittest.TestCase):
             """
         t = timeit.Timer(stmt=s)
         timing = t.timeit(number=NUMBER)
-        print timing
         self.assertGreater(timing, 0.)
 
         timing_vector = t.repeat(number=NUMBER, repeat=10)
-        print timing_vector
         self.assertEqual(len(timing_vector), 10)
         self.assertGreater(min(timing_vector), 0.)
 

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -11,11 +11,11 @@ NUMBER = 10000  # Of times to execute in each test
 class TestTimeit(unittest.TestCase):
 
     def test_oct(self):
-        timing = timeit.Timer('for i in xrange(100): oct(i)', 'gc.enable()').timeit(number=NUMBER)
+        timing = timeit.Timer('for i in xrange(10): oct(i)', 'gc.enable()').timeit(number=NUMBER)
         print timing
         self.assertGreater(timing, 0.)
 
-        timing_vector = timeit.Timer('for i in xrange(100): oct(i)').repeat(number=NUMBER)
+        timing_vector = timeit.Timer('for i in xrange(10): oct(i)').repeat(number=NUMBER)
         print timing_vector
         self.assertEqual(len(timing_vector), 3)
         self.assertGreater(min(timing_vector), 0.)

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -14,7 +14,7 @@ class TestTimeit(unittest.TestCase):
         timing = timeit.Timer('for i in xrange(100): oct(i)', 'gc.enable()').timeit(number=NUMBER)
         self.assertGreater(timing, 0.)
 
-        timing_vector = timeit.Timer('for i in xrange(10): oct(i)').repeat(number=NUMBER)
+        timing_vector = timeit.Timer('for i in xrange(100): oct(i)').repeat(number=NUMBER)
         self.assertEqual(len(timing_vector), 3)
         self.assertGreater(min(timing_vector), 0.)
 

--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -6,14 +6,19 @@ import test.test_support
 # changed number=10000 so we don't spend too much time testing this
 # module in the regrtest
 
+NUMBER = 10000  # Of times to execute in each test
+
 class TestTimeit(unittest.TestCase):
 
     def test_oct(self):
-        timing = timeit.Timer('for i in xrange(10): oct(i)', 'gc.enable()').timeit(number=10000)
-        self.assertTrue(timing > 0.)
-        timing_vector = timeit.Timer('for i in xrange(10): oct(i)').repeat(number=10000)
+        timing = timeit.Timer('for i in xrange(100): oct(i)', 'gc.enable()').timeit(number=NUMBER)
+        print timing
+        self.assertGreater(timing, 0.)
+
+        timing_vector = timeit.Timer('for i in xrange(100): oct(i)').repeat(number=NUMBER)
+        print timing_vector
         self.assertEqual(len(timing_vector), 3)
-        self.assertTrue(min(timing_vector) > 0.)
+        self.assertGreater(min(timing_vector), 0.)
 
     def test_str(self):
         s = """\
@@ -23,11 +28,14 @@ class TestTimeit(unittest.TestCase):
                 pass
             """
         t = timeit.Timer(stmt=s)
-        self.assertTrue(t.timeit(number=10000) > 0.)
+        timing = t.timeit(number=NUMBER)
+        print timing
+        self.assertGreater(timing, 0.)
 
-        timing_vector = t.repeat(number=10000, repeat=10)
+        timing_vector = t.repeat(number=NUMBER, repeat=10)
+        print timing_vector
         self.assertEqual(len(timing_vector), 10)
-        self.assertTrue(min(timing_vector) > 0.)
+        self.assertGreater(min(timing_vector), 0.)
 
 
 def test_main():


### PR DESCRIPTION
`test.test_timeit` has started failing on the Windows CI because time measurements are sometimes zero. We attribute this to a fast machine and the granularity of the Windows clock.

Here is a version that takes a little longer. There are print statements to test the hypothesis about the cause.

This may take a few annoyingly trivial change sets to settle.