### PR TITLE
Re-enable some regression tests

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -619,6 +619,8 @@ def runtest_inner(test, verbose, quiet, test_times,
             # explicitly invoke their test_main() function (if it exists).
             indirect_test = getattr(the_module, "test_main", None)
             test_time = None
+            if indirect_test is None:                   # JA Temporary
+                print "%s has no test_main" % test      #
             if indirect_test is not None:
                 indirect_test()
             elif junit_xml_dir:

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -619,8 +619,6 @@ def runtest_inner(test, verbose, quiet, test_times,
             # explicitly invoke their test_main() function (if it exists).
             indirect_test = getattr(the_module, "test_main", None)
             test_time = None
-            if indirect_test is None:                   # JA Temporary
-                print "%s has no test_main" % test      #
             if indirect_test is not None:
                 indirect_test()
             elif junit_xml_dir:

--- a/Lib/test/test_decimal_jy.py
+++ b/Lib/test/test_decimal_jy.py
@@ -23,12 +23,15 @@ class TestJavaDecimal(unittest.TestCase):
         x = Decimal("1.1")
         y = x.__tojava__(Float)
         self.assertTrue(isinstance(y, Float))
-    
+
     def test_double(self):
         x = Decimal("1.1")
         y = x.__tojava__(Double)
         self.assertTrue(isinstance(y, Double))
 
 
+def test_main():
+    test_support.run_unittest(TestJavaDecimal)
+
 if __name__ == '__main__':
-    unittest.main()
+    test_main()

--- a/Lib/test/test_decimal_jy.py
+++ b/Lib/test/test_decimal_jy.py
@@ -17,7 +17,7 @@ class TestJavaDecimal(unittest.TestCase):
     def test_object(self):
         x = Decimal("1.1")
         y = x.__tojava__(Object)
-        self.assertTrue(isinstance(y, BigDecimal))        
+        self.assertTrue(isinstance(y, BigDecimal))
 
     def test_float(self):
         x = Decimal("1.1")

--- a/Lib/test/test_finalizers.py
+++ b/Lib/test/test_finalizers.py
@@ -5,6 +5,10 @@ Created on 06.08.2014
 import unittest
 import types
 import time
+
+from test import test_support
+
+
 try:
     from java.lang import System
 except:
@@ -12,7 +16,7 @@ except:
 
 class GCDetector():
     gcIndex = 0
-    
+
     def __del__(self):
         GCDetector.gcIndex += 1
 
@@ -117,22 +121,22 @@ delN = __del__N
 
 
 class DummyClass():
-    
+
     def __init__(self, name):
         self.name = name
-    
+
     def __str__(self):
         return self.name
 
 
 class DummyClassDel():
-    
+
     def __init__(self, name):
         self.name = name
-    
+
     def __str__(self):
         return self.name
-    
+
     def __del__(self):
         finalizeMsgList.append(str(self)+" finalized (DummyClassDel)")
         if verbose:
@@ -140,31 +144,31 @@ class DummyClassDel():
 
 
 class DummyClassNew(object):
-    
+
     def __init__(self, name):
         self.name = name
-    
+
     def __str__(self):
         return self.name
 
 class DummyClassDelNew(object):
-    
+
     def __init__(self, name):
         self.name = name
-    
+
     def __str__(self):
         return self.name
-    
+
     def __del__(self):
         finalizeMsgList.append(str(self)+" finalized (DummyClassDelNew)")
         if verbose:
             print str(self)+" finalized (DummyClassDelNew)"
 
 class DummyFileClassNew(file):
-    
+
     def __init__(self, name):
         self.name0 = name
-    
+
     def __str__(self):
         return self.name0
 
@@ -295,7 +299,7 @@ class TestFinalizers(unittest.TestCase):
         ResurrectableDummyClass.__del__ = delJ
         J = ResurrectableDummyClass("J")
         J = None
-        
+
         runGCIfJython()
         self.assertIn("J finalized (ResurrectableDummyClass)", finalizeMsgList)
         global resurrectedObject_J
@@ -321,10 +325,10 @@ class TestFinalizers(unittest.TestCase):
         except:
             pass
         resurrectedObject_J = None
-        
+
         runGCIfJython()
         self.assertIsNone(resurrectedObject_J)
-        
+
 
     def test_objectDoubleResurrectionAndFinalize_oldStyleClass(self):
         #okay to fail in Jython without the manual __ensure_finalizer__ calls
@@ -413,6 +417,9 @@ class TestFinalizers(unittest.TestCase):
         runGCIfJython()
         self.assertIn("O finalized (DummyFileClassNew)", finalizeMsgList)
 
-if __name__ == '__main__':
-    unittest.main()
 
+def test_main():
+    test_support.run_unittest(TestFinalizers)
+
+if __name__ == '__main__':
+    test_main()

--- a/Lib/test/test_isatty.py
+++ b/Lib/test/test_isatty.py
@@ -36,14 +36,10 @@ class IsattyTest(unittest.TestCase):
         self.assertEqual(subprocess.check_call(args_list(*args), **kw), 0)
 
     def test_isatty(self):
-        if os.name == 'java': # Jython doesn't allocate ptys here
-            self.check_call(False, False, False)
-            # XXX not sure how to test anything else
-        else:
-            self.check_call(True, True, True)
-            self.check_call(False, True, True, stdin=subprocess.PIPE)
-            self.check_call(True, False, True, stdout=subprocess.PIPE)
-            self.check_call(True, True, False, stderr=subprocess.PIPE)
+        self.check_call(True, True, True)
+        self.check_call(False, True, True, stdin=subprocess.PIPE)
+        self.check_call(True, False, True, stdout=subprocess.PIPE)
+        self.check_call(True, True, False, stderr=subprocess.PIPE)
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:

--- a/Lib/test/test_resurrection_attr_preserve.py
+++ b/Lib/test/test_resurrection_attr_preserve.py
@@ -3,6 +3,8 @@ import gc
 import time
 import weakref
 
+from test import test_support
+
 class ReferentDummy:
     def __init__(self, name):
         self.name = name
@@ -93,5 +95,8 @@ class GCTests(unittest.TestCase):
 
 
 
+def test_main():
+    test_support.run_unittest(GCTests)
+
 if __name__ == '__main__':
-    unittest.main()
+    test_main()

--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -317,9 +317,9 @@ def load_tests(loader, suite, pattern):
 def test_main():
     support.run_unittest(tests)
     support.run_unittest(
-        PasswordProtectedSiteTestCase,
         NetworkTestCase,
-        )
+        PasswordProtectedSiteTestCase,
+    )
 
 if __name__=='__main__':
     support.verbose = 1

--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -295,9 +295,9 @@ class PasswordProtectedSiteTestCase(unittest.TestCase):
     def __str__(self):
         return '%s' % self.__class__.__name__
 
+
 class NetworkTestCase(unittest.TestCase):
 
-    @unittest.skip('does not handle the gzip encoding delivered by pydotorg')
     def testPythonOrg(self):
         support.requires('network')
         with support.transient_internet('www.python.org'):
@@ -313,5 +313,14 @@ def load_tests(loader, suite, pattern):
     suite.addTest(PasswordProtectedSiteTestCase())
     return suite
 
+
+def test_main():
+    support.run_unittest(tests)
+    support.run_unittest(
+        PasswordProtectedSiteTestCase,
+        NetworkTestCase,
+        )
+
 if __name__=='__main__':
-    unittest.main()
+    support.verbose = 1
+    test_main()

--- a/Lib/test/test_str2unicode.py
+++ b/Lib/test/test_str2unicode.py
@@ -1,5 +1,7 @@
 import unittest
 
+from test import test_support
+
 
 class TestStrReturnsUnicode(unittest.TestCase):
 
@@ -14,10 +16,7 @@ class TestStrReturnsUnicode(unittest.TestCase):
         self.assertEquals(unicode, type('%s %s' % (u'x', 'y')))
         self.assertEquals(unicode, type('%(x)s' % {'x' : u'x'}))
 
-    def test_string_formatting_r(self):
-        self.assertEquals(unicode, type('%r' % u'x'))
-        self.assertEquals(unicode, type('%r %r' % (u'x', 'y')))
-        self.assertEquals(unicode, type('%(x)r' % {'x' : u'x'}))
+    # Note: no test_string_formatting_r as %r always produces bytes
 
     def test_string_formatting_c(self):
         self.assertEquals(unicode, type('%c' % u'x'))
@@ -86,5 +85,12 @@ class TestUnicodeReturnsUnicode(unittest.TestCase):
         self.assertEquals(unicode, type(u'%(x)c' % {'x' : 'x'}))
 
 
+def test_main():
+    test_support.run_unittest(
+        TestStrReturnsUnicode,
+        TestStrReturnsStr,
+        TestUnicodeReturnsUnicode,
+    )
+
 if __name__ == '__main__':
-    unittest.main()
+    test_main()


### PR DESCRIPTION
`test.regrtest` imports modules named `test_*` and if they have a `test_main()`, calls it. Tests must therefore either run on import, or via test_main. Most tests use the `__name__ == '__main__'` convention to skip the run on import, but some forgot to add `test_main()`. We correct this in a handful of cases.

We adjust the test content to enable previously skipped cases.