### PR TITLE
Exclude duplicate org.w3c.* from JARs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,7 @@ New Features
 Jython 2.7.4a1 Bugs fixed
     - [ GH-304 ] from java import * not working in Java 21
     - [ GH-302 ] Interactive interpreter awaits input instead of raising syntax error
+    - [ GH-288 ] Build fails when using java module
     - [ GH-280 ] LineNumberTable deprecated for removal in 2.6 still there
     - [ GH-277 ] Argument coercion fails for Java interface with default methods
     - [ GH-269 ] Upgrade Google Guava to 32.0.1 (CVE-2023-2976)

--- a/build.xml
+++ b/build.xml
@@ -902,7 +902,8 @@ The text for an official release would continue like ...
             <zipfileset src="${extlibs.dir}/jnr-ffi-2.2.12.jar"/>
             <zipfileset src="${extlibs.dir}/jnr-netdb-1.2.0.jar"/>
             <zipfileset src="${extlibs.dir}/jnr-posix-3.1.15.jar"/>
-            <zipfileset src="extlibs/xercesImpl-2.12.2.jar" excludes="META-INF/services/*"/>
+            <zipfileset src="extlibs/xercesImpl-2.12.2.jar"
+                excludes="META-INF/services/*, org/w3c/**"/>
             <rule pattern="org.apache.xml.**" result="org.python.apache.xml.@1"/>
             <rule pattern="org.apache.xerces.**" result="org.python.apache.xerces.@1"/>
             <rule pattern="org.apache.wml.**" result="org.python.apache.wml.@1"/>


### PR DESCRIPTION
Fixes #288, where the fact that `xercesImpl` contains a copy of `org.w3c.dom.html.HTMLDOMImplementation` causes (post-Jigsaw) Java to object that there are two suppliers for `org.w3c.dom.html`.