### PR TITLE
Add upward compatibility to Java 9 Modularity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -649,6 +649,7 @@ jar {
         attributes ([
             'Main-Class': 'org.python.util.jython',
             'Built-By': 'build.gradle',
+            'Automatic-Module-Name': 'org.python.jython'
         ])
 
         attributes( [ // Build-Info section

--- a/build.xml
+++ b/build.xml
@@ -916,6 +916,7 @@ The text for an official release would continue like ...
             <manifest>
                 <attribute name="Main-Class" value="org.python.util.jython" />
                 <attribute name="Built-By" value="${user.name}" />
+                <attribute name="Automatic-Module-Name" value="org.python.jython"/>
                 <attribute name="Implementation-Vendor" value="Python Software Foundation"/>
                 <attribute name="Implementation-Title" value="Jython fat jar"/>
                 <attribute name="Implementation-Version" value="${jython.version}"/>
@@ -939,6 +940,7 @@ The text for an official release would continue like ...
             <manifest>
                 <attribute name="Main-Class" value="org.python.util.jython" />
                 <attribute name="Built-By" value="${user.name}" />
+                <attribute name="Automatic-Module-Name" value="org.python.jython"/>
                 <attribute name="Implementation-Vendor" value="Python Software Foundation"/>
                 <attribute name="Implementation-Title" value="Jython fat jar with stdlib"/>
                 <attribute name="Implementation-Version" value="${jython.version}"/>
@@ -982,6 +984,7 @@ The text for an official release would continue like ...
             <manifest>
                 <attribute name="Main-Class" value="org.python.util.jython" />
                 <attribute name="Built-By" value="${user.name}" />
+                <attribute name="Automatic-Module-Name" value="org.python.jython"/>
                 <attribute name="Implementation-Vendor" value="Python Software Foundation"/>
                 <attribute name="Implementation-Title" value="Jython"/>
                 <attribute name="Implementation-Version" value="${jython.version}"/>


### PR DESCRIPTION
I've noticed that Jython uses 1.8 source and target compatibility, but when Jython is used as a  Maven/Gradle dependency with Java >= 9 it becomes an unnamed module. Adding the `Automatic-Module-Name` attribute in the jar's manifest resolves this issue, so named modules can require on a save way on it, without need to move Jython to Java 9. The Java 8 build will not be affected by this change, and for java module users it increase stability instead of the module name derived from the jar file name.

Now have a look if the module name `org.python.jython` fits, or if you prefer another name instead. In case of keep compatibility to the module name derived from the jar file name, the module name should be changed to `jython`, as this is the name that Java derives from the jar file published on Maven Central.