### PR TITLE
Catch IndexError when accessing sys.argv

### DIFF
--- a/ACKNOWLEDGMENTS
+++ b/ACKNOWLEDGMENTS
@@ -206,6 +206,7 @@ In no particular order they are:
     Phil Turmel (GitHub: pturmel)                   C, 2023-12-30
     lifebarier (GitHub: lifebarier)                 C, 2024-03-06
     Adrian Ross (GitHub: R077A6r1an)                C, 2024-04-09
+    John Hubbard (GitHub: jhubbardbnso)             C, 2024-06-06
 
 
 Since about 2012 we have been asking contributors to sign the Python

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -224,7 +224,7 @@ def warn(message, category=None, stacklevel=1):
         if module == "__main__":
             try:
                 filename = sys.argv[0]
-            except (AttributeError, TypeError):
+            except (AttributeError, TypeError, IndexError):
                 # embedded interpreters don't have sys.argv, see bug #839151
                 filename = '__main__'
         if not filename:


### PR DESCRIPTION
This change was approved as part of https://github.com/jython/jython-bad-history/pull/42 but it appears that it was submitted during the period where the repo had a broken history.   As such and I'm submitting it again for consideration.  

As before, our application replies on an embedded interpreter and when run without this change we see:

```$ echo "print(Misc.getRelease())" | RunScript
Exception in thread "main" Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/jhubbard/Downloads/jython-standalone-2.7.3.jar/Lib/warnings$py.class", line 226, in warn
  File "/home/jhubbard/Downloads/jython-standalone-2.7.3.jar/Lib/warnings$py.class", line 226, in warn
IndexError: index out of range: 0
```
The fix here is to catch the index error in the except block and assume `__main__` just like in the event of a Attribute or Type Error.  