### PR TITLE
Fix #335 Overloaded varargs method preference

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,7 +32,7 @@ New Features
 
 Jython 2.7.4b3 Bugs fixed
 
-
+    - [ GH-335 ] Method resolution for overridden variable arity changed as a result of PR #282
 
 Jython 2.7.4b2 Feature added
 

--- a/src/org/python/core/PyReflectedConstructor.java
+++ b/src/org/python/core/PyReflectedConstructor.java
@@ -162,7 +162,7 @@ public class PyReflectedConstructor extends PyReflectedFunction {
                         if (!argslist[i].isVarArgs) {
                             method = argslist[i].method;
                             break;
-                        } else {
+                        } else if (varargMatch == null) {
                             varargMatch = argslist[i].method;
                             varargData = callData;
                             callData = new ReflectedCallData();

--- a/src/org/python/core/PyReflectedFunction.java
+++ b/src/org/python/core/PyReflectedFunction.java
@@ -173,7 +173,7 @@ public class PyReflectedFunction extends PyObject implements Traverseproc {
             if (argslist[i].matches(self, args, keywords, callData)) {
                 if (!argslist[i].isVarArgs) {
                     match = argslist[i];
-                } else {
+                } else if (varargMatch == null) {
                     varargMatch = argslist[i];
                     varargData = callData;
                     callData = new ReflectedCallData();

--- a/tests/java/javatests/Reflection.java
+++ b/tests/java/javatests/Reflection.java
@@ -129,6 +129,10 @@ public class Reflection {
             constructorVersion = "int, int...";
         }
 
+        public Overloaded(boolean a, boolean... others) {
+            constructorVersion = "boolean, boolean...";
+        }
+
         public Overloaded(String s) {
             constructorVersion = "String";
         }
@@ -163,6 +167,10 @@ public class Reflection {
 
         public String foo(int... a) {
             return "int...";
+        }
+
+        public String foo(boolean a, boolean... b) {
+            return "boolean, boolean...";
         }
 
         public String bar(int a) {


### PR DESCRIPTION
The resolution for #221 resulted in non varargs methods/ctors being given preference as designed.  However it also resulted in a change in which vararg methods/ctors was selected.  To restore the old behavior only update the candidate varagsMatch the first time a candidate match is found.  This restores the previous behavior WRT var args while retaining the desired preference for non varargs methods/ctors.

Update the test case to attempt to trigger the issue that the rest of this commit addresses.