### PR TITLE
export xml.parsers and xml.etree like Python 2.7

### DIFF
--- a/Lib/xml/__init__.py
+++ b/Lib/xml/__init__.py
@@ -1,18 +1,23 @@
 """Core XML support for Jython.
 
-This package contains two sub-packages:
+This package contains four sub-packages:
 
 dom -- The W3C Document Object Model.  This supports DOM Level 1 +
        Namespaces.
+
+parsers -- Python wrappers for XML parsers (currently only supports Expat).
 
 sax -- The Simple API for XML, developed by XML-Dev, led by David
        Megginson and ported to Python by Lars Marius Garshol.  This
        supports the SAX 2 API.
 
+etree -- The ElementTree XML library.  This is a subset of the full
+       ElementTree XML release.
+
 """
 
-__all__ = ['dom', 'sax']
 
+__all__ = ["dom", "parsers", "sax", "etree"]
 
 _MINIMUM_XMLPLUS_VERSION = (0, 8, 5)
 


### PR DESCRIPTION
Export the same modules as the upstream, see https://github.com/python/cpython/blob/v2.7.18/Lib/xml/__init__.py