### PR TITLE
Update GitHub actions for Node20

### DIFF
--- a/.github/workflows/ant-javatest.yml
+++ b/.github/workflows/ant-javatest.yml
@@ -29,10 +29,10 @@ jobs:
     # Some tests require exactly-expected line endings
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'

--- a/.github/workflows/ant-regrtest.yml
+++ b/.github/workflows/ant-regrtest.yml
@@ -23,10 +23,10 @@ jobs:
     # Some tests require exactly-expected line endings
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 8
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
         distribution: 'temurin'
@@ -45,10 +45,10 @@ jobs:
     # Some tests require exactly-expected line endings
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: pip install codespell
     - run: codespell --count --ignore-words=Misc/codespell/words.ignore
                   NEWS README.md README.txt LICENSE.txt Misc/INDEX Misc/codespell/README

--- a/.github/workflows/launcher-test.yml
+++ b/.github/workflows/launcher-test.yml
@@ -28,10 +28,10 @@ jobs:
     # Some tests require exactly-expected line endings
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 8
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
         distribution: 'temurin'


### PR DESCRIPTION
Required by GitHub Actions platform change. Current workflows generate the warning referred to here: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ .


