### PR TITLE
Impose timeout on regrtest workflows

### DIFF
--- a/.github/workflows/ant-regrtest.yml
+++ b/.github/workflows/ant-regrtest.yml
@@ -16,7 +16,7 @@ jobs:
   ant-regrtest-ubuntu-jdk8:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 40
 
     steps:
     - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
@@ -39,7 +39,7 @@ jobs:
   ant-regrtest-windows-jdk11:
 
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 60
 
     steps:
     - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."

--- a/.github/workflows/ant-regrtest.yml
+++ b/.github/workflows/ant-regrtest.yml
@@ -16,6 +16,7 @@ jobs:
   ant-regrtest-ubuntu-jdk8:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
     - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
@@ -38,6 +39,7 @@ jobs:
   ant-regrtest-windows-jdk11:
 
     runs-on: windows-latest
+    timeout-minutes: 5
 
     steps:
     - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."


### PR DESCRIPTION
Workflows occasionally hang unnoticed. Then they waste 6 hours of CPU.

This timeout is too short, but I want to test that it works. The normal run-time is 15-30 minutes.