### PR TITLE
Replaced property sun.stdout.encoding with stdout.encoding

### DIFF
--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -1023,7 +1023,7 @@ public class PySystemState extends PyObject
     private static String getConsoleEncoding(Properties props) {
 
         // From Java 8 onwards, the answer may already be to hand in the registry:
-        String encoding = props.getProperty("sun.stdout.encoding");
+        String encoding = props.getProperty("stdout.encoding");
         String os = props.getProperty("os.name");
 
         if (encoding != null) {

--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -1022,8 +1022,7 @@ public class PySystemState extends PyObject
      */
     private static String getConsoleEncoding(Properties props) {
 
-        // From Java 8 onwards, the answer may already be to hand in the registry:
-        String encoding = props.getProperty("stdout.encoding");
+        String encoding = props.getProperty("stdout.encoding");  // Java 19+
         String os = props.getProperty("os.name");
 
         if (encoding != null) {


### PR DESCRIPTION
The `stdout.encoding` and `stderr.encoding` system properties were added in JDK 19, formalized from the previous internal-use-only property `sun.stdout.encoding`.