### PR TITLE
Add support for Windows Code Page 65001 (UTF-8)

### DIFF
--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -1033,13 +1033,19 @@ public class PySystemState extends PyObject
             // Go via the Windows code page built-in command "chcp".
             String output = Py.getCommandResultWindows("chcp");
             /*
-             * The output will be like "Active code page: 850" or maybe "Aktive Codepage: 1252." or
+             * The output will be like "Active code page: 850" or maybe "Active Codepage: 1252." or
              * "활성 코드 페이지: 949". Assume the first number with 2 or more digits is the code page.
              */
             final Pattern DIGITS_PATTERN = Pattern.compile("[1-9]\\d+");
             Matcher matcher = DIGITS_PATTERN.matcher(output);
             if (matcher.find()) {
-                return "cp".concat(output.substring(matcher.start(), matcher.end()));
+                String codePage = "cp".concat(output.substring(matcher.start(), matcher.end()));
+                // cp65001 is UTF-8
+                if (codePage.equals("cp65001")) {
+                    return "utf-8";
+                } else {
+                    return codePage;
+                }
             }
 
         } else {


### PR DESCRIPTION
When the Code Page is set to 65001 (UTF-8), using command `chcp.com 65001`, then the following code should display the correct output:

```python
unicode_string = u"Hello World: \u2764"
print unicode_string
```