### PR TITLE
Fix the Maven badge for Jython in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Jython: Python for the Java Platform
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.python/jython-standalone/badge.svg)](https://search.maven.org/artifact/org.python/jython-standalone/)
+[![Maven Central](https://maven-badges.sml.io/maven-central/org.python/jython-standalone/badge.svg)](https://search.maven.org/artifact/org.python/jython-standalone/)
 [![Javadocs](https://www.javadoc.io/badge/org.python/jython-standalone.svg)](https://www.javadoc.io/doc/org.python/jython-standalone)
 [![APIdia](https://apidia.net/java/Jython/badge.svg)](https://apidia.net/java/Jython)
 


### PR DESCRIPTION
<img width="310" height="45" alt="image" src="https://github.com/user-attachments/assets/090236be-1f20-4f79-9da6-33aef3887748" />

fixed and now displayed as

<img width="327" height="36" alt="image" src="https://github.com/user-attachments/assets/d7218623-543d-4e1d-9760-437a2cf8a87a" />
