### PR TITLE
Add simple workflow to run test from verbose.tests

### DIFF
--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -42,7 +42,7 @@ jobs:
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
-        export PYENV_ROOT="$HOME/.pyenv
+        export PYENV_ROOT="$HOME/.pyenv"
         export PATH="$PYENV_ROOT/bin:$PATH"
 
     - name: Check pyenv has taken.

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -1,0 +1,53 @@
+# Run ant regrtest -f verbose.tests on Jython 2.7 on Java versions (GitHub action)
+
+# We expect this to fail (at the time of writing) and the purpose
+# is to tell us on which OSes and versions of Java that happens,
+# with details.
+
+name: Java versions regrtest 2.7 (verbose.tests)
+
+# Only run manually as we don't want to block every PR.
+on:
+  push:
+    # This is here so we can test the jobs on push
+    branches:
+      - 'test-java-17-25-short'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  java-versions-regrtest:
+    strategy:
+      max-parallel: 2
+      matrix:
+        version: [17, 25]
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    continue-on-error: true
+
+    steps:
+    - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
+    - run: echo "Java ${{ matrix.version }} on ${{ matrix.os }}."
+
+    # Some tests require exactly-expected line endings
+    - run: git config --global core.autocrlf input
+
+    - uses: actions/checkout@v6
+
+    - name: Set up JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ matrix.version }}
+        distribution: 'temurin'
+
+    - name: Developer build with Ant
+      run: ant -noinput -buildfile build.xml developer-build
+
+    - name: Specified regression tests with Ant
+      run: dist/bin/jython -m test.regrtest -v -f verbose.tests
+

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -27,7 +27,7 @@ jobs:
       max-parallel: 2
       matrix:
         version: [17, 25]
-        os: [ubuntu-latest, windows-latest]
+        os: ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -42,10 +42,9 @@ jobs:
 
     - uses: actions/checkout@v6
 
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v5
-      with:
-        python-version: 2.7
+    # Some tests require Python 2.7 available (not sure it is)
+    - name: Ensure Python 2.7 available
+      run: python -V
 
     - name: Set up JDK
       uses: actions/setup-java@v5

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        version: [17, 25]
-        os: [ubuntu-22.04, ubuntu-latest]
+        version: [17]
+        os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -37,26 +37,20 @@ jobs:
     - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
     - run: echo "Java ${{ matrix.version }} on ${{ matrix.os }}."
 
-    # Some tests require exactly-expected line endings
-    - run: git config --global core.autocrlf input
-
-    - uses: actions/checkout@v6
-
     # Some tests require Python 2.7 available (not sure it is)
     - name: Install pyenv for choice of Python version.
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
-        echo BASH_ENV = "$BASH_ENV"
-        echo PATH = "$PATH"
-        ls -a .*
-        ~/.pyenv/bin/pyenv init --install
+        export PYENV_ROOT="$HOME/.pyenv
+        export PATH="$PYENV_ROOT/bin:$PATH"
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation
       run: |
-        exec "$SHELL"
-        cat ~/.profile
+        echo BASH_ENV = "$BASH_ENV"
+        echo PATH = "$PATH"
+        pyenv init --install
 
     - name: Ensure Python 2.7 available
       run: |
@@ -64,6 +58,10 @@ jobs:
         pyenv install 2.7
         pyenv global 2.7
         python -V
+
+    # Some tests require exactly-expected line endings
+    - run: git config --global core.autocrlf input
+    - uses: actions/checkout@v6
 
     - name: Set up JDK
       uses: actions/setup-java@v5

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -55,7 +55,7 @@ jobs:
         #echo 'eval "$(pyenv init - bash)"' >> ~/.bash_profile
         # Add to subsequent environments through GITHUB_ variables (files)
         echo "PYENV_ROOT=$HOME/.pyenv" >> "$GITHUB_ENV"
-        echo "$PYENV_ROOT/bin:$PATH" >> "$GITHUB_PATH"
+        echo "$HOME/.pyenv/bin" >> "$GITHUB_PATH"
         # Which are visible?
         echo BASH_ENV = "$BASH_ENV"
         echo PYENV_ROOT = "$PYENV_ROOT"

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -47,8 +47,16 @@ jobs:
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
+        echo BASH_ENV = "$BASH_ENV"
+        echo PATH = "$PATH"
+        ls -a .*
         ~/.pyenv/bin/pyenv init --install
+
+    - name: Check pyenv has taken.
+      # See https://github.com/pyenv/pyenv#installation
+      run: |
         exec "$SHELL"
+        cat ~/.profile
 
     - name: Ensure Python 2.7 available
       run: |

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -45,15 +45,17 @@ jobs:
     # Some tests require Python 2.7 available (not sure it is)
     - name: Install pyenv for choice of Python version.
       # See https://github.com/pyenv/pyenv#installation
-      run: curl -sSL https://pyenv.run | bash
-      run: ~/.pyenv/bin/pyenv init --install
-      run: exec "$SHELL"
+      run: |
+        curl -sSL https://pyenv.run | bash
+        ~/.pyenv/bin/pyenv init --install
+        exec "$SHELL"
 
     - name: Ensure Python 2.7 available
-      run: pyenv versions
-      run: pyenv install 2.7
-      run: pyenv global 2.7
-      run: python -V
+      run: |
+        pyenv versions
+        pyenv install 2.7
+        pyenv global 2.7
+        python -V
 
     - name: Set up JDK
       uses: actions/setup-java@v5

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -42,16 +42,22 @@ jobs:
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
-        ls -al .*
-        echo "Running pyenv init --install"
-        ~/.pyenv/bin/pyenv init --install
-        echo "What did we modify?"
-        ls -al .*
+        ls -al ~
+        echo "Manual equivalent of pyenv init --install"
+        #~/.pyenv/bin/pyenv init --install
+        # Modify (create) .bashrc
+        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+        echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
+        # Modify (create) .profile
+        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
+        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
+        echo 'eval "$(pyenv init - bash)"' >> ~/.profile        echo "What did we modify?"
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation
       run: |
-        ls -al .*
+        ls -al ~
         echo BASH_ENV = "$BASH_ENV"
         echo PATH = "$PATH"
         pyenv versions

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -42,11 +42,16 @@ jobs:
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
+        ls -al .*
+        echo "Running pyenv init --install"
         ~/.pyenv/bin/pyenv init --install
+        echo "What did we modify?"
+        ls -al .*
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation
       run: |
+        ls -al .*
         echo BASH_ENV = "$BASH_ENV"
         echo PATH = "$PATH"
         pyenv versions

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -4,15 +4,18 @@
 # is to tell us on which OSes and versions of Java that happens,
 # with details.
 
-name: Java versions regrtest 2.7 (verbose.tests)
+name: Java versions regrtest 2.7 (verbose tests)
 
 # Only run manually as we don't want to block every PR.
 on:
-  push:
-    # This is here so we can test the jobs on push
-    branches:
-      - 'test-java-17-25-short'
   workflow_dispatch:
+    # So we may run on demand (with a chosen file)
+   inputs:
+     tests_file:
+       description: 'File containing the names of tests to run'
+       type: string
+       required: true
+       default: 'verbose.tests'
 
 permissions:
   contents: read
@@ -39,6 +42,11 @@ jobs:
 
     - uses: actions/checkout@v6
 
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v5
+      with:
+        python-version: 2.7
+
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
@@ -49,5 +57,5 @@ jobs:
       run: ant -noinput -buildfile build.xml developer-build
 
     - name: Specified regression tests with Ant
-      run: dist/bin/jython -m test.regrtest -v -f verbose.tests
+      run: dist/bin/jython -m test.regrtest -v -f ${{ tests_file }}
 

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -49,10 +49,10 @@ jobs:
         echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
         echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
         echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
-        # Modify (create) .profile
-        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile
-        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile
-        echo 'eval "$(pyenv init - bash)"' >> ~/.profile        echo "What did we modify?"
+        # Modify (create) .bash_profile
+        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+        echo 'eval "$(pyenv init - bash)"' >> ~/.bash_profile
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -46,19 +46,27 @@ jobs:
         echo "Manual equivalent of pyenv init --install"
         #~/.pyenv/bin/pyenv init --install
         # Modify (create) .bashrc
-        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-        echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
+        #echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+        #echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+        #echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
         # Modify (create) .bash_profile
-        echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
-        echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
-        echo 'eval "$(pyenv init - bash)"' >> ~/.bash_profile
+        #echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+        #echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+        #echo 'eval "$(pyenv init - bash)"' >> ~/.bash_profile
+        # Add to subsequent environments through GITHUB_ variables (files)
+        echo "PYENV_ROOT=$HOME/.pyenv" >> "$GITHUB_ENV"
+        echo "$PYENV_ROOT/bin:$PATH" >> "$GITHUB_PATH"
+        # Which are visible?
+        echo BASH_ENV = "$BASH_ENV"
+        echo PYENV_ROOT = "$PYENV_ROOT"
+        echo PATH = "$PATH"
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation
       run: |
         ls -al ~
         echo BASH_ENV = "$BASH_ENV"
+        echo PYENV_ROOT = "$PYENV_ROOT"
         echo PATH = "$PATH"
         pyenv versions
 

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        version: [25]
-        os: [ubuntu-22.04]
+        version: [25, 17]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -27,7 +27,7 @@ jobs:
       max-parallel: 2
       matrix:
         version: [17, 25]
-        os: ubuntu-22.04
+        os: [ubuntu-22.04, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -42,20 +42,19 @@ jobs:
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
-        export PYENV_ROOT="$HOME/.pyenv"
-        export PATH="$PYENV_ROOT/bin:$PATH"
+        ~/.pyenv/bin/pyenv init --install
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation
       run: |
         echo BASH_ENV = "$BASH_ENV"
         echo PATH = "$PATH"
-        pyenv init --install
+        pyenv versions
 
     - name: Ensure Python 2.7 available
       run: |
-        pyenv versions
         pyenv install 2.7
+        pyenv versions
         pyenv global 2.7
         python -V
 

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -43,7 +43,16 @@ jobs:
     - uses: actions/checkout@v6
 
     # Some tests require Python 2.7 available (not sure it is)
+    - name: Install pyenv for choice of Python version.
+      # See https://github.com/pyenv/pyenv#installation
+      run: curl -sSL https://pyenv.run | bash
+      run: ~/.pyenv/bin/pyenv init --install
+      run: exec "$SHELL"
+
     - name: Ensure Python 2.7 available
+      run: pyenv versions
+      run: pyenv install 2.7
+      run: pyenv global 2.7
       run: python -V
 
     - name: Set up JDK

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        version: [17]
+        version: [25]
         os: [ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
@@ -42,29 +42,15 @@ jobs:
       # See https://github.com/pyenv/pyenv#installation
       run: |
         curl -sSL https://pyenv.run | bash
-        ls -al ~
-        echo "Manual equivalent of pyenv init --install"
-        #~/.pyenv/bin/pyenv init --install
-        # Modify (create) .bashrc
-        #echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-        #echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-        #echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
-        # Modify (create) .bash_profile
-        #echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
-        #echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
-        #echo 'eval "$(pyenv init - bash)"' >> ~/.bash_profile
+        # Manual equivalent of "pyenv init --install".
         # Add to subsequent environments through GITHUB_ variables (files)
         echo "PYENV_ROOT=$HOME/.pyenv" >> "$GITHUB_ENV"
         echo "$HOME/.pyenv/bin" >> "$GITHUB_PATH"
-        # Which are visible?
-        echo BASH_ENV = "$BASH_ENV"
-        echo PYENV_ROOT = "$PYENV_ROOT"
-        echo PATH = "$PATH"
+        echo "$HOME/.pyenv/shims" >> "$GITHUB_PATH"
 
     - name: Check pyenv has taken.
       # See https://github.com/pyenv/pyenv#installation
       run: |
-        ls -al ~
         echo BASH_ENV = "$BASH_ENV"
         echo PYENV_ROOT = "$PYENV_ROOT"
         echo PATH = "$PATH"
@@ -91,5 +77,7 @@ jobs:
       run: ant -noinput -buildfile build.xml developer-build
 
     - name: Specified regression tests with Ant
-      run: dist/bin/jython -m test.regrtest -v -f ${{ inputs.tests_file }}
+      run: |
+        python -V
+        dist/bin/jython -m test.regrtest -v -f ${{ inputs.tests_file }}
 

--- a/.github/workflows/java-versions-verbose-tests.yml
+++ b/.github/workflows/java-versions-verbose-tests.yml
@@ -57,5 +57,5 @@ jobs:
       run: ant -noinput -buildfile build.xml developer-build
 
     - name: Specified regression tests with Ant
-      run: dist/bin/jython -m test.regrtest -v -f ${{ tests_file }}
+      run: dist/bin/jython -m test.regrtest -v -f ${{ inputs.tests_file }}
 

--- a/verbose.tests
+++ b/verbose.tests
@@ -1,6 +1,6 @@
 # verbose.tests
 # List of tests referenced by GitHub action java-versions-verbose-tests.yml
-# Test with: -m test.regrtest -v -f verbose.tests
+# Test with: dist/bin/jython -m test.regrtest -v -f verbose.tests
 
 test_cmd_line
 test_float_jy

--- a/verbose.tests
+++ b/verbose.tests
@@ -1,0 +1,18 @@
+# verbose.tests
+# List of tests referenced by GitHub action java-versions-verbose-tests.yml
+# Test with: -m test.regrtest -v -f verbose.tests
+
+test_cmd_line
+test_float_jy
+test_httplib
+test_import_jy
+test_java_integration
+test_java_visibility  # warning: Ignoring option --illegal-access=warn;
+test_json
+test_jy_internals
+test_jython_launcher
+test_socket           # fails Linux (socket in use on rerun)
+test_socket_jy        # fails Linux (socket in use on rerun)
+test_subprocess
+test_threading
+test_urllib2_localnet


### PR DESCRIPTION
The existing workflow for Java 17 and 25 compatibility uses an Ant target that runs the regrtest normally, then re-runs the failed tests in verbose mode, so we can see exactly which tests fail and the cause. When it comes to networking tests, this is unsatisfactory if they fail to close their sockets, which they frequently do on failure, since the verbose run then fails comprehensively because the sockets are busy, not for the original cause.

This workflow allows us to specify which tests to run verbose, so that we may run just the ones that caused trouble.