### PR TITLE
Filter META-INF sub-folder from shaded JARs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,7 @@ New Features
       the registry or on the command line. The default (for now) is true.
 
 Jython 2.7.5a1 Bugs fixed
+    - [ GH-452 ] Incorrect construction of release JARs
     - [ GH-434 ] CVE-2023-34462(CVSS 6.5), CVE-2022-41915(CVSS 6.5) Jython 2.7.4 using a vulnerable Netty version 4.1.173.Final
     - [ GH-430 ] CVE-2026-5598 (CVSS 8.9) - Jython 2.7.4 using a vulnerable Bouncy Castle version 1.78.1
     - [ GH-416 ] Solve serialization backward incompatibility of oversized methods and functions

--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,8 @@ dependencies {
     implementation 'org.ow2.asm:asm-commons:9.10.1'
     implementation 'org.ow2.asm:asm-util:9.10.1'
 
+    implementation 'com.google.guava:guava:33.6.0-jre'
+
     // Pin icu4j to latest 77.x until Jython moves to Java 11.
     // https://unicode-org.github.io/icu/download/77.html
     implementation 'com.ibm.icu:icu4j:77.1'

--- a/build.xml
+++ b/build.xml
@@ -861,7 +861,7 @@ The text for an official release would continue like ...
             <rule pattern="org.apache.commons.compress.**" result="org.python.apache.commons.compress.@1"/>
             <zipfileset src="extlibs/commons-io-2.22.0.jar" excludes="META-INF/versions/9/module-info.class"/>
             <rule pattern="org.apache.commons.io.**" result="org.python.apache.commons.io.@1"/>
-            <zipfileset src="extlibs/failureaccess-1.0.3.jar"/>
+            <zipfileset src="extlibs/failureaccess-1.0.3.jar" excludes="META-INF/**"/>
             <zipfileset src="extlibs/guava-33.6.0-jre.jar" excludes="META-INF/**"/>
             <rule pattern="com.google.**" result="org.python.google.@1"/>
             <zipfileset src="extlibs/icu4j-77.1.jar"/>


### PR DESCRIPTION
Fixes #452 which was preventing a 2.7.5b1 release.